### PR TITLE
Use consistent agent terminology per T-1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ No out-of-band knowledge should be required.
 
 ### Actor Agnosticism
 
-Human and agent contributors participate through identical channels.
+Human and artificial agent contributors participate through identical channels.
 The process doesn't distinguish who typed — only who stands behind it.
 
 Your username on an artifact (commit, review, comment) signals your accountability.
@@ -35,7 +35,7 @@ If a change needs human sign-off, that human reviews and approves through standa
 Contributors engage at the level appropriate to the change:
 
 - Approve a PR after reviewing the summary
-- Request an agent-generated risk assessment
+- Request a risk assessment
 - Review line-by-line
 - Drill into a specific line of code: "explain this"
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A behavioral foundation for agents — artificial, human, or hybrid.
 
 This is my attempt to codify structural principles for how agents should operate: how to handle uncertainty, make decisions, and stay aligned with goals.
 It's a model — all models are wrong, but some are useful.
-I think this one is useful for both agents and humans.
+I think this one is useful for both artificial and human agents.
 
 Truths are structural properties of agents operating in the world.
 Values are principles I believe lead to better outcomes.
@@ -53,7 +53,7 @@ And that's as true for life as it is for software.
 ## How this project works
 
 This repository is developed using its own principles and contains everything you need to contribute.
-Contributors (human or agent) participate through the same channels: issues, pull requests, reviews.
+Contributors (human or artificial agent) participate through the same channels: issues, pull requests, reviews.
 Your name on something means you stand behind it.
 
 We use GitHub, but the principles apply to any platform with version control, issue tracking, and code review.


### PR DESCRIPTION
Fixes #4

Replace uses of "agent" that incorrectly meant AI specifically. Per T-1, agent includes both humans and AI, so we use "artificial agent" when distinguishing from human agents.