### PR TITLE
Rename Agent Kernel to Agent Framework

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This document defines the collaboration model and governance process for the Agent Kernel project.
+This document defines the collaboration model and governance process for the Agent Framework project.
 
 ## A Note on Contributions
 
@@ -102,7 +102,7 @@ The goal is clarity at the appropriate level, not uniform tone.
 ## Versioning
 
 This project uses semantic versioning.
-The mapping of version increments to kernel layers will be defined via RFC once the layer model is accepted.
+The mapping of version increments to framework layers will be defined via RFC once the layer model is accepted.
 
 ## Platform
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Agent Kernel
+Agent Framework
 Copyright 2026 John Dyreby
 
 This product includes software developed by John Dyreby.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Agent Kernel
+# Agent Framework
 
 A behavioral foundation for agents — artificial, human, or hybrid.
 
@@ -12,7 +12,7 @@ Truths are structural properties of agents operating in the world.
 Values are principles I believe lead to better outcomes.
 Everything else is built on that foundation.
 
-The kernel is a layered architecture:
+The framework is a layered architecture:
 
 - **Truths** — Structural properties of agents. What they are, not what they should do.
 - **Values** — Guiding principles for decisions when tradeoffs exist.
@@ -45,7 +45,7 @@ This kind of collaboration requires:
 - Clear interfaces for proposing, reviewing, and taking action towards the goal
 - The ability to engage at any depth — from quick approval to thorough review
 
-The Agent Kernel provides the shared principles. The process provides the rest.
+The Agent Framework provides the shared principles. The process provides the rest.
 
 Because ultimately, principles and process drive quality, not the actor.
 And that's as true for life as it is for software.


### PR DESCRIPTION
Closes #5

Update project name in README, CONTRIBUTING, and NOTICE.
Historical documents (RFCs, ADRs) left unchanged per immutability policy.

After merge, the GitHub repository will be renamed from `agent-kernel` to `agent-framework`.