### PR TITLE
Align README with new framework structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,10 +50,9 @@ Location: `docs/rfcs/`
 
 RFCs propose significant changes:
 
-- Truth or Value layer modifications
-- Structural changes to Roles, Skills, or Profiles
+- Foundation or core changes
 - Governance process changes
-- New adapter contracts
+- New tool integrations
 
 Routine additions to Roles, Skills, and Profiles can go through regular PRs.
 
@@ -102,7 +101,7 @@ The goal is clarity at the appropriate level, not uniform tone.
 ## Versioning
 
 This project uses semantic versioning.
-The mapping of version increments to framework layers will be defined via RFC once the layer model is accepted.
+The mapping of version increments to the framework structure will be defined via RFC once the structure is stable.
 
 ## Platform
 

--- a/README.md
+++ b/README.md
@@ -32,25 +32,40 @@ You try to stay aligned with what matters while the world shifts around you.
 
 So does everyone else. So does every AI.
 
-This model helps you navigate the uncertainty. You can see what's real versus what's your thinking. You can act with intention instead of drifting. You can let go of what isn't true.
+This model helps you navigate the uncertainty.
+You can see what's real versus what's your thinking.
+You can act with intention instead of drifting.
+You can let go of what isn't true.
 
-When working with others, sharing a framework is more important than agreeing on everything. A shared framework makes collaboration more effective because it frames discussions around alignment. Are we disagreeing about what matters, or just about how to do it? Shared foundations make the work light.
+When working with others, sharing a framework is more important than agreeing on everything.
+A shared framework makes collaboration more effective because it frames discussions around alignment.
+Are we disagreeing about what matters, or just about how to do it?
+Shared foundations make the work light.
 
 ## What's the goal?
 
 I want AI agents that think and work the way I do.
 
-This project is how I'm doing it. My theory is that the more an agent aligns with how I think, from Truths down to preferences, the more effectively we can collaborate.
+This project is how I'm doing it.
+My theory is that the more an agent aligns with how I think, from Truths down to preferences, the more effectively we can collaborate.
 
-The framework is durable. The model I build on it is mine. The artifacts that implement it for tools like pi can evolve with the technology without affecting either.
+The framework is durable.
+The model I build on it is mine.
+The artifacts that implement it for my current tools can evolve with the technology without affecting either.
 
 ## How this project works
 
-This project is the test. I'm developing it with AI agents as collaborators, using the same channels: issues, pull requests, reviews.
+This project is the test of that theory.
+I'm developing it with my current agent, based on [pi](https://github.com/mariozechner/pi-coding-agent), as a collaborator using software development best practices.
 
-Human or AI, the process is the same.
+Along the way, I help my agent do its job better.
+As it improves, the work gets better and iteration gets faster.
+I participate where I add the most value.
 
-As the project evolves, the agents improve. Better agents mean better work and faster iteration. I participate along the way where I think I add the most value.
+Eventually, the agent just does what I ask.
+And I have a better understanding of what's reasonable to ask.
+
+Until then, any misalignment is either a bug to fix or a lesson to learn.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 


### PR DESCRIPTION
## Summary

Rewrite README to align with evolved understanding of the framework structure and goals. Update CONTRIBUTING to match new terminology.

## How This Unfolded

Started with updating the GH 'about' after the rename from agent-kernel to agent-framework. While iterating on the README, the structural understanding evolved:

- 'Layers' didn't fit — Truths are invariants, not a layer
- Core abstractions (Principles, Roles, Skills) are orthogonal, not stacked
- 'Values' undersells what they are — renamed to 'Principles'

This PR captures that evolution. RFC-02 (PR #11) formalizes the structural decision.

## Key Changes

### README

**Structure: Layers → Foundation/Core/Shell**
- Truths are the foundation (not a layer)
- Principles, Roles, Skills are the core (orthogonal, not stacked)
- Profiles are the shell (wiring)

**Terminology**
- Values → Principles
- Tagline: 'A framework for acting in an uncertain world'

**New section: What's the goal?**
- Explains the AI alignment theory
- 'The more an agent aligns with how I think, from Truths down to preferences, the more effectively we can collaborate'

**Revised: How this project works**
- Introduces pi with link
- Describes the feedback loop: agent improves as project evolves
- Clarifies two roles: collaborator and guide

**Why does this matter?**
- Focused on personal value (navigating uncertainty)
- Collaboration section tightened

### CONTRIBUTING

- Values → Principles
- 'layer' terminology → foundation/core/shell
- 'adapter contracts' → 'tool integrations'
- RFC scope simplified to 'Foundation or core changes'

## Related

- RFC-02: [Foundation/Core/Shell structure](https://github.com/dyreby/agent-framework/pull/11) (formalizes the structural decision)