### PR TITLE
Clarify 'shared model' wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can let go of what isn't true.
 When working with others, sharing a framework is more important than agreeing on everything.
 A shared framework makes collaboration more effective because it frames discussions around alignment.
 Are we disagreeing about what matters, or just about how to do it?
-Shared foundations make the work light.
+A shared model of what should be done and how to do it makes the work light.
 
 ## What's the goal?
 


### PR DESCRIPTION
Replace 'Shared foundations make the work light' with more explicit phrasing about what a shared model means: alignment on both what should be done and how to do it.