### PR TITLE
Fix gh-agent using wrong identity for gh commands

### DIFF
--- a/extensions/gh-agent/gh-command.ts
+++ b/extensions/gh-agent/gh-command.ts
@@ -49,9 +49,8 @@ export async function executeGhCommand(
     };
   }
 
-  const result = await pi.exec("bash", ["-c", command], {
+  const result = await pi.exec("env", [`GH_TOKEN=${agentToken}`, "bash", "-c", command], {
     signal,
-    env: { ...process.env, GH_TOKEN: agentToken },
   });
 
   const output = [result.stdout, result.stderr]


### PR DESCRIPTION
Fixes #21

`pi.exec` does not support the `env` option, so `GH_TOKEN` was being silently ignored. Commands ran with the user's default `gh` credentials instead of the agent token.

**Fix:** Use the `env` command to inject `GH_TOKEN` into the subprocess environment.