### PR TITLE
Use isolated GH_CONFIG_DIR instead of token in process args

### DIFF
--- a/extensions/gh-agent/config.ts
+++ b/extensions/gh-agent/config.ts
@@ -1,14 +1,60 @@
 /**
  * Configuration loading for gh-agent.
  *
- * Uses an isolated gh config directory to avoid token exposure in process args.
+ * Combines settings-based username with isolated GH_CONFIG_DIR for security.
+ * No token in process args, explicit username in settings (no regex parsing).
  */
 
+import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-/** Isolated gh config directory for agent identity. */
-export const GH_CONFIG_DIR = join(homedir(), ".pi", "agent", "gh-config");
+const SETTINGS_PATH = join(homedir(), ".pi", "agent", "settings.json");
+const GH_CONFIG_BASE = join(homedir(), ".pi", "agent", "gh-config");
 
-/** Setup command for users to run. */
-export const SETUP_COMMAND = `GH_CONFIG_DIR="${GH_CONFIG_DIR}" gh auth login`;
+export type Config =
+  | { ok: true; username: string; configDir: string }
+  | { ok: false; error: string };
+
+/**
+ * Get the GH_CONFIG_DIR path for a given username.
+ */
+export function getConfigDir(username: string): string {
+  return join(GH_CONFIG_BASE, username);
+}
+
+/**
+ * Get the setup command for a given username.
+ */
+export function getSetupCommand(username: string): string {
+  return `GH_CONFIG_DIR="${getConfigDir(username)}" gh auth login`;
+}
+
+/**
+ * Read gh-agent configuration from pi settings.
+ */
+export function readConfig(): Config {
+  try {
+    const content = readFileSync(SETTINGS_PATH, "utf-8");
+    const settings = JSON.parse(content);
+
+    const username = settings["gh-agent"]?.username;
+    if (!username || typeof username !== "string") {
+      return {
+        ok: false,
+        error: `Add to ${SETTINGS_PATH}: { "gh-agent": { "username": "your-github-agent-username" } }`,
+      };
+    }
+
+    return { ok: true, username, configDir: getConfigDir(username) };
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException;
+    if (err.code === "ENOENT") {
+      return {
+        ok: false,
+        error: `Add to ${SETTINGS_PATH}: { "gh-agent": { "username": "your-github-agent-username" } }`,
+      };
+    }
+    return { ok: false, error: `Failed to read settings: ${err.message}` };
+  }
+}

--- a/extensions/gh-agent/gh-command.ts
+++ b/extensions/gh-agent/gh-command.ts
@@ -4,7 +4,6 @@
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { isAllowed } from "./allow-list.ts";
-import { SETUP_COMMAND } from "./config.ts";
 
 export interface GhCommandContext {
   pi: ExtensionAPI;

--- a/extensions/gh-agent/index.ts
+++ b/extensions/gh-agent/index.ts
@@ -6,38 +6,46 @@
  * about this — it just uses `gh` normally.
  *
  * Setup:
- *   GH_CONFIG_DIR=~/.pi/agent/gh-config gh auth login
+ *   1. Add to ~/.pi/agent/settings.json:
+ *      { "gh-agent": { "username": "your-github-agent-username" } }
+ *   2. Run: GH_CONFIG_DIR=~/.pi/agent/gh-config/{username} gh auth login
  */
 
 import { createBashTool } from "@mariozechner/pi-coding-agent";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { GH_CONFIG_DIR, SETUP_COMMAND } from "./config.ts";
+import { readConfig, getSetupCommand } from "./config.ts";
 import { executeGhCommand, type GhCommandContext } from "./gh-command.ts";
 
 export default function (pi: ExtensionAPI) {
   const ghCtx: GhCommandContext = {
     pi,
-    configDir: GH_CONFIG_DIR,
+    configDir: "",
     configError: null,
   };
 
   pi.on("session_start", async (_event, ctx) => {
+    const config = readConfig();
+
+    if (!config.ok) {
+      ghCtx.configError = config.error;
+      ctx.ui.notify(`gh-agent: ${config.error}`, "error");
+      return;
+    }
+
+    ghCtx.configDir = config.configDir;
+
     // Verify auth is configured in isolated config dir
-    const result = await pi.exec("env", [`GH_CONFIG_DIR=${GH_CONFIG_DIR}`, "gh", "auth", "status"]);
+    const result = await pi.exec("env", [`GH_CONFIG_DIR=${config.configDir}`, "gh", "auth", "status"]);
 
     if (result.code !== 0) {
-      ghCtx.configError = `Agent auth not configured. Run: ${SETUP_COMMAND}`;
+      ghCtx.configError = `Auth not configured. Run: ${getSetupCommand(config.username)}`;
       ctx.ui.notify(`gh-agent: ${ghCtx.configError}`, "error");
       return;
     }
 
-    // Extract username from auth status output
-    const match = result.stdout.match(/Logged in to github\.com account (\S+)/);
-    const username = match?.[1] ?? "agent";
-
     ctx.ui.setStatus(
       "gh-agent",
-      ctx.ui.theme.fg("success", `gh: ${username}`)
+      ctx.ui.theme.fg("success", `gh: ${config.username}`)
     );
   });
 


### PR DESCRIPTION
Fixes #21

The previous approach (PR #22) passed `GH_TOKEN` via command-line args, exposing the long-lived OAuth token in process listings (`ps aux`).

This uses an isolated gh config directory instead—only a path appears in argv.

**Setup:**
```bash
GH_CONFIG_DIR=~/.pi/agent/gh-config gh auth login
```

Supersedes #22.