### PR TITLE
Allowlist gh search prs and gh pr status

### DIFF
--- a/extensions/gh-agent/allow-list.ts
+++ b/extensions/gh-agent/allow-list.ts
@@ -22,6 +22,10 @@ const ALLOWED_COMMANDS = [
   "pr diff",
   "pr review",
   "pr edit",
+  "pr status",
+
+  // Search
+  "search prs",
 ] as const;
 
 /** Allowed API endpoint patterns (supports * wildcards for single path segments) */

--- a/extensions/gh-agent/test/allow-list.test.ts
+++ b/extensions/gh-agent/test/allow-list.test.ts
@@ -63,6 +63,16 @@ describe("isAllowed", () => {
       const result = isAllowed("gh pr edit 123 --body 'Updated'");
       assert.strictEqual(result.allowed, true);
     });
+
+    it("allows pr status", () => {
+      const result = isAllowed("gh pr status");
+      assert.strictEqual(result.allowed, true);
+    });
+
+    it("allows search prs", () => {
+      const result = isAllowed("gh search prs --review-requested=john-agent --state=open");
+      assert.strictEqual(result.allowed, true);
+    });
   });
 
   describe("blocked commands (dangerous)", () => {


### PR DESCRIPTION
Closes #27

Adds read-only PR discovery commands to the allowlist:
- `pr status` — see PRs needing attention
- `search prs` — find PRs by criteria (review-requested, author, state)