### PR TITLE
Fix RFC-03 migration section that contradicted immutability

### DIFF
--- a/docs/rfcs/rfc-03-foundation-revision.md
+++ b/docs/rfcs/rfc-03-foundation-revision.md
@@ -175,9 +175,8 @@ The *source* of objectives and models differs, but the structural properties are
 
 ## Migration
 
-- RFC-01 status updated to "Superseded by RFC-03"
-- ADR-01 remains valid (records original decision)
-- New ADR-03 records this revision decision
+- This RFC supersedes RFC-01 (declared in header)
+- ADR-03 supersedes ADR-01 (declared in its header)
 - Version increments to v0.2.0
 
 ## References


### PR DESCRIPTION
The migration section said 'RFC-01 status updated to...' which implied editing an immutable document. This contradicted CONTRIBUTING.md.

Making an exception to immutability because:
- This fixes guidance that would cause governance violations
- The architectural decision is unchanged
- Leaving it would mislead future contributors