### PR TITLE
Add RFC-04 and ADR-04: Foundation Extension

### DIFF
--- a/docs/adrs/adr-04-foundation-extension.md
+++ b/docs/adrs/adr-04-foundation-extension.md
@@ -1,6 +1,6 @@
 # ADR-04: Foundation Extension
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-02-16
 - **RFC:** [RFC-04](../rfcs/rfc-04-foundation-extension.md)
 - **Extends:** ADR-03 (Foundation Revision)
@@ -77,7 +77,6 @@ These are now structural consequences within the framework.
 
 ## Consequences
 
-- Framework version increments to v0.3.0
 - Foundation encoded as five Truths: T-1 through T-5
 - Presuppositions remain unchanged (P-0 through P-4, not encoded)
 - ADR-03 remains as historical record; this ADR captures current state

--- a/docs/rfcs/rfc-04-foundation-extension.md
+++ b/docs/rfcs/rfc-04-foundation-extension.md
@@ -1,6 +1,6 @@
 # RFC-04: Foundation Extension
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Created:** 2026-02-15
 - **Extends:** RFC-03 (Foundation Revision)
 
@@ -148,7 +148,6 @@ T-3 immediately after T-2 connects objectives to models. T-4 establishes epistem
 
 - This RFC extends RFC-03 (not supersedes — the original truths remain)
 - ADR-04 will reference this RFC
-- Version increments to v0.3.0
 
 ## References
 


### PR DESCRIPTION
Extend the foundation from three truths to five, adding:

- **T-3: Model Complexity** — More complex models require more input
- **T-4: Model-Objective Bridge** — Agents use world models to select actions in pursuit of objectives

## Why

These additions close two gaps identified in RFC-03:

1. **Missing bridge**: T-1 (objectives) and T-2 (world models) were independent claims with no explicit connection
2. **Missing complexity claim**: "Simpler models are better" couldn't be derived structurally without T-3

With these truths, "simpler is better" becomes a logical consequence rather than a principle (opinion).