### PR TITLE
Add endpoint to list PR review comments

### DIFF
--- a/extensions/gh-agent/allow-list.ts
+++ b/extensions/gh-agent/allow-list.ts
@@ -30,6 +30,8 @@ const ALLOWED_COMMANDS = [
 
 /** Allowed API endpoint patterns (supports * wildcards for single path segments) */
 const ALLOWED_API_PATTERNS = [
+  // List PR review comments
+  "repos/*/*/pulls/*/comments",
   // Reply to inline PR comments
   "repos/*/*/pulls/*/comments/*/replies",
   // Edit issue comments

--- a/extensions/gh-agent/test/allow-list.test.ts
+++ b/extensions/gh-agent/test/allow-list.test.ts
@@ -123,6 +123,11 @@ describe("isAllowed", () => {
   });
 
   describe("API commands", () => {
+    it("allows listing PR review comments (GET)", () => {
+      const result = isAllowed("gh api repos/owner/repo/pulls/1/comments");
+      assert.strictEqual(result.allowed, true);
+    });
+
     it("allows replying to inline PR comments (POST)", () => {
       const result = isAllowed(
         'gh api repos/owner/repo/pulls/1/comments/123/replies -X POST -f body="Reply"'


### PR DESCRIPTION
Add `repos/*/*/pulls/*/comments` pattern to the API allow list, enabling discovery of review comment IDs needed for reading/replying to inline comments.

Closes #38