### PR TITLE
Add RFC-05: Intent-Expression Gap

### DIFF
--- a/docs/adrs/adr-05-intent-expression-gap.md
+++ b/docs/adrs/adr-05-intent-expression-gap.md
@@ -7,15 +7,15 @@
 
 ## Context
 
-ADR-04 established five Truths, including T-5 (Context Efficiency): the context a user must provide is the gap between agent understanding and situation requirements.
+ADR-04 established five Truths, including T-5 (Context Efficiency): required context is the gap between agent understanding and situation requirements.
 
-But T-5 assumes users *can* express what they want accurately. They often can't:
+But T-5 assumes intent sources *can* express what they want accurately. They often can't:
 
 1. **Expression is lossy**: Natural language compresses and introduces ambiguity
-2. **Users describe solutions, not problems**: The XY problem — asking about Y when the real goal is X
-3. **Intent ≠ expression**: Users can't be wrong about what they want, but can be wrong about how to express it
+2. **Solutions get stated instead of problems**: The XY problem — asking about Y when the real goal is X
+3. **Intent ≠ expression**: Sources of intent can't be wrong about what they want, but can be wrong about how to express it
 
-This is distinct from T-2 (imperfect world models). Even a perfect model receiving user expression would face the intent-expression gap. World state (files, repo content) can be taken as given; user expression of intent cannot.
+This is distinct from T-2 (imperfect world models). Even a perfect model receiving intent expression would face the intent-expression gap. World state (files, repo content) can be taken as given; intent expression cannot.
 
 ## Decision
 
@@ -36,10 +36,10 @@ Agents use their world models to select actions in pursuit of objectives.
 World input and model-derived conclusions are distinct. World input is taken as given.
 
 **T-5: Context Efficiency**
-The context a user must provide is the gap between the agent's existing understanding and the situation's requirements.
+Required context is the gap between agent understanding and situation requirements.
 
 **T-6: Intent-Expression Gap**
-Users communicate intent imperfectly. Agents must infer intent from expression, not treat expression as intent.
+Expressed intent is lossy. Agents must infer intent from expression, not treat expression as intent.
 
 ### Encoding for LLM Context
 
@@ -54,17 +54,17 @@ T-3: Agents use their world models to select actions in pursuit of objectives.
 
 T-4: World input and model-derived conclusions are distinct. World input is taken as given.
 
-T-5: The context a user must provide is the gap between the agent's existing understanding and the situation's requirements.
+T-5: Required context is the gap between agent understanding and situation requirements.
 
-T-6: Users communicate intent imperfectly. Agents must infer intent from expression, not treat expression as intent.
+T-6: Expressed intent is lossy. Agents must infer intent from expression, not treat expression as intent.
 ```
 
 ### Integration with Existing Truths
 
 | Truth | Relationship to T-6 |
 |-------|---------------------|
-| T-2: Imperfect World Model | T-6 identifies a specific source of imperfection: user expression |
-| T-4: Input Distinction | User expression is world input, taken as given — but as a signal, not ground truth about intent |
+| T-2: Imperfect World Model | T-6 identifies a specific source of imperfection: intent expression |
+| T-4: Input Distinction | Intent expression is world input, taken as given — but as a signal, not ground truth about intent |
 | T-5: Context Efficiency | The "gap" now has two components: agent understanding *and* expression fidelity |
 
 ### Key Derivations Now Possible
@@ -73,7 +73,7 @@ T-6: Users communicate intent imperfectly. Agents must infer intent from express
 - T-6 → Expression ≠ intent, so agents that clarify are actively aligning to user intent
 
 **"Pushback can be correct"**
-- T-6 → Users can be wrong about how to express what they want
+- T-6 → Intent sources can be wrong about how to express what they want
 - Derivation: "You asked for Y, but it sounds like you want X — is that right?" is doing the job
 - World context (files, repo state) aids this: "given what I see in your codebase, you might mean..."
 
@@ -83,9 +83,11 @@ T-6: Users communicate intent imperfectly. Agents must infer intent from express
 
 ### Why T-6 is a Truth, Not a Derivation
 
-T-6 is not derivable from T-2 (imperfect world models). T-2 says the agent's model is imperfect; T-6 says user *intent expression* is lossy — a claim about the nature of human-agent communication, not agent internals.
+T-6 is not derivable from T-2 (imperfect world models). T-2 says the agent's model is imperfect; T-6 says *intent expression* is lossy — a claim about the nature of intent communication, not agent internals.
 
 Even a perfect model would face the intent-expression gap. This is structural.
+
+Examples clarify: a human user asking a coding agent about JSON parsing when they need to extract an API field; a developer asking a colleague the same question. The truth applies to any agent receiving expressed intent — the examples help readers infer what we mean by the abstract claim. (This is itself T-6 in action.)
 
 ## Consequences
 

--- a/docs/rfcs/rfc-05-intent-expression-gap.md
+++ b/docs/rfcs/rfc-05-intent-expression-gap.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-Add a sixth truth establishing that users communicate intent imperfectly, and agents must infer intent from expression rather than treating expression as intent.
+Add a sixth truth establishing that expressed intent is lossy, and agents must infer intent from expression rather than treating expression as intent.
 
 ## Motivation
 
@@ -42,10 +42,10 @@ This justifies agent behaviors that would otherwise seem presumptuous: asking "w
 ### New Truth
 
 **T-6: Intent-Expression Gap**
-Users communicate intent imperfectly. Agents must infer intent from expression, not treat expression as intent.
+Expressed intent is lossy. Agents must infer intent from expression, not treat expression as intent.
 
-- User input is world input (per T-4), but it's a *signal about* intent, not intent itself
-- Users can't be wrong about what they want — but they can be wrong about how to express it
+- Intent expression is world input (per T-4), but it's a *signal about* intent, not intent itself
+- Sources of intent can't be wrong about what they want — but they can be wrong about how to express it
 - Agents should model the gap and work to close it through clarification
 - This enables XY problem detection: user asks Y, but underlying X suggests a different path
 
@@ -53,8 +53,8 @@ Users communicate intent imperfectly. Agents must infer intent from expression, 
 
 | Truth | Relationship to T-6 |
 |-------|---------------------|
-| T-2: Imperfect World Model | T-6 identifies a specific source of imperfection: user expression |
-| T-4: Input Distinction | User expression is world input, taken as given — but as a signal, not ground truth about intent |
+| T-2: Imperfect World Model | T-6 identifies a specific source of imperfection: intent expression |
+| T-4: Input Distinction | Intent expression is world input, taken as given — but as a signal, not ground truth about intent |
 | T-5: Context Efficiency | The "gap" now has two components: agent understanding *and* expression fidelity |
 
 ### Derived Consequences
@@ -86,9 +86,9 @@ T-3: Agents use their world models to select actions in pursuit of objectives.
 
 T-4: World input and model-derived conclusions are distinct. World input is taken as given.
 
-T-5: The context a user must provide is the gap between the agent's existing understanding and the situation's requirements.
+T-5: Required context is the gap between agent understanding and situation requirements.
 
-T-6: Users communicate intent imperfectly. Agents must infer intent from expression, not treat expression as intent.
+T-6: Expressed intent is lossy. Agents must infer intent from expression, not treat expression as intent.
 ```
 
 ## Discussion
@@ -97,17 +97,21 @@ T-6: Users communicate intent imperfectly. Agents must infer intent from express
 
 You might argue this follows from T-2 (imperfect world models) — if user input feeds the model, and models are imperfect, user input is imperfectly processed.
 
-But that misses the point. T-6 claims something specific: **user intent expression is lossy**, not just the processing. Even a perfect model receiving user expression would face the intent-expression gap.
+But that misses the point. T-6 claims something specific: **intent expression is lossy**, not just the processing. Even a perfect model receiving intent expression would face the intent-expression gap.
 
-To be precise: "input" here means user-provided prompting that expresses a desired outcome. World state — file content, repo structure, website content — is not lossy in this sense. It can be taken as given and used *to resolve* lossy intent expression.
+To be precise: "expression" here means communication that conveys a desired outcome. World state — file content, repo structure, website content — is not lossy in this sense. It can be taken as given and used *to resolve* lossy intent expression.
 
-This is a structural claim about the nature of human-agent communication, distinct from claims about agent internals.
+This is a structural claim about the nature of intent communication, distinct from claims about agent internals.
 
 ### This isn't unique to agents
 
 The intent-expression gap exists in human-human communication too. A developer asks a colleague "how do I parse JSON in bash?" — but they actually need to extract one field from an API response. The colleague might answer the literal question (jq, sed gymnastics) or recognize the XY problem and ask "what are you actually trying to get?"
 
 Agents face this same dynamic. The difference: agents can be *designed* to look for it.
+
+### Meta-example: This Document
+
+This RFC itself demonstrates T-6. We include concrete examples (coding agents, human-human communication) to help readers infer our intent from our necessarily imperfect expression of it. The examples are not the truth — they're signals to close the gap between what we mean and what we wrote.
 
 ### Doesn't this make agents second-guess everything?
 


### PR DESCRIPTION
Propose T-6: Users communicate intent imperfectly. Agents must infer intent from expression, not treat expression as intent.

Motivated by line comments on #34 — the insight that users can't be wrong about what they want, but can be wrong about how to express it.

## Why a separate RFC?

Small steps. RFC-04 addresses the model-objective bridge. This addresses a distinct structural claim about user-agent communication.

## Key derivations

- **Clarification is alignment work** — agents that clarify are actively aligning to intent
- **Pushback can be correct** — "you asked Y, but it sounds like you want X" is doing the job
- **Solutions ≠ goals** — users often describe solutions when they have goals (XY problem)