### PR TITLE
gh-agent: intercept gh commands in compound statements

### DIFF
--- a/extensions/gh-agent/gh-command.ts
+++ b/extensions/gh-agent/gh-command.ts
@@ -18,7 +18,66 @@ export interface CommandResult {
 }
 
 /**
- * Execute a gh command with agent identity.
+ * Check if a command contains any gh invocations.
+ */
+export function containsGhCommand(command: string): boolean {
+  // Match `gh ` at start or after shell operators/subshell markers
+  return /(?:^|[;&|()]|\$\()\s*gh\s/.test(command);
+}
+
+/**
+ * Extract all gh commands from a compound shell statement.
+ * Returns the full gh command including arguments for each invocation.
+ */
+export function extractGhCommands(command: string): string[] {
+  const commands: string[] = [];
+
+  // Split on shell operators, preserving quoted strings
+  // This handles: cmd1 && gh pr create && cmd2
+  //               cmd1; gh issue list; cmd2
+  //               cmd1 || gh pr view
+  //               (gh pr list)
+  //               $(gh pr view 123)
+  const pattern = /(?:^|[;&|()]|\$\()\s*(gh\s+[^;&|()$]+)/g;
+  let match;
+
+  while ((match = pattern.exec(command)) !== null) {
+    const ghCmd = match[1].trim();
+    if (ghCmd) {
+      commands.push(ghCmd);
+    }
+  }
+
+  return commands;
+}
+
+/**
+ * Validate all gh commands in a compound statement.
+ * Returns validation result - if any command fails, returns that failure.
+ */
+export function validateGhCommands(
+  command: string
+): { allowed: true } | { allowed: false; reason: string } {
+  const ghCommands = extractGhCommands(command);
+
+  if (ghCommands.length === 0) {
+    // No gh commands found - shouldn't happen if caller checks containsGhCommand first
+    return { allowed: true };
+  }
+
+  for (const ghCmd of ghCommands) {
+    const validation = isAllowed(ghCmd);
+    if (!validation.allowed) {
+      return validation;
+    }
+  }
+
+  return { allowed: true };
+}
+
+/**
+ * Execute a command containing gh invocations with agent identity.
+ * Validates all gh commands before execution.
  */
 export async function executeGhCommand(
   command: string,
@@ -34,7 +93,7 @@ export async function executeGhCommand(
     };
   }
 
-  const validation = isAllowed(command);
+  const validation = validateGhCommands(command);
   if (!validation.allowed) {
     return {
       content: [{ type: "text", text: `gh-agent: ${validation.reason}` }],

--- a/extensions/gh-agent/index.ts
+++ b/extensions/gh-agent/index.ts
@@ -14,7 +14,7 @@
 import { createBashTool } from "@mariozechner/pi-coding-agent";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { readConfig, getSetupCommand } from "./config.ts";
-import { executeGhCommand, type GhCommandContext } from "./gh-command.ts";
+import { executeGhCommand, containsGhCommand, type GhCommandContext } from "./gh-command.ts";
 
 export default function (pi: ExtensionAPI) {
   const ghCtx: GhCommandContext = {
@@ -56,7 +56,7 @@ export default function (pi: ExtensionAPI) {
     async execute(id, params, signal, onUpdate, ctx) {
       const { command } = params as { command: string };
 
-      if (command.trim().startsWith("gh ")) {
+      if (containsGhCommand(command)) {
         return executeGhCommand(command, ghCtx, signal);
       }
 

--- a/extensions/gh-agent/test/gh-command.test.ts
+++ b/extensions/gh-agent/test/gh-command.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { containsGhCommand, extractGhCommands, validateGhCommands } from "../gh-command.ts";
+
+describe("containsGhCommand", () => {
+  it("detects gh at start of command", () => {
+    assert.strictEqual(containsGhCommand("gh pr create"), true);
+  });
+
+  it("detects gh after &&", () => {
+    assert.strictEqual(containsGhCommand("cd /path && gh pr create"), true);
+  });
+
+  it("detects gh after ;", () => {
+    assert.strictEqual(containsGhCommand("echo hello; gh issue list"), true);
+  });
+
+  it("detects gh after ||", () => {
+    assert.strictEqual(containsGhCommand("false || gh pr view 1"), true);
+  });
+
+  it("detects gh in subshell", () => {
+    assert.strictEqual(containsGhCommand("(gh pr list)"), true);
+  });
+
+  it("detects gh in command substitution", () => {
+    assert.strictEqual(containsGhCommand("echo $(gh pr view 1 --json number)"), true);
+  });
+
+  it("returns false for commands without gh", () => {
+    assert.strictEqual(containsGhCommand("cd /path && ls"), false);
+  });
+
+  it("returns false for gh substring in other words", () => {
+    assert.strictEqual(containsGhCommand("echo spaghetti"), false);
+  });
+});
+
+describe("extractGhCommands", () => {
+  it("extracts single gh command", () => {
+    const cmds = extractGhCommands("gh pr create --title 'Test'");
+    assert.deepStrictEqual(cmds, ["gh pr create --title 'Test'"]);
+  });
+
+  it("extracts gh command after &&", () => {
+    const cmds = extractGhCommands("cd /path && gh pr create --title 'Test'");
+    assert.deepStrictEqual(cmds, ["gh pr create --title 'Test'"]);
+  });
+
+  it("extracts gh command after ;", () => {
+    const cmds = extractGhCommands("echo done; gh issue list");
+    assert.deepStrictEqual(cmds, ["gh issue list"]);
+  });
+
+  it("extracts multiple gh commands", () => {
+    const cmds = extractGhCommands("gh pr list && gh issue list");
+    assert.deepStrictEqual(cmds, ["gh pr list", "gh issue list"]);
+  });
+
+  it("extracts gh command from subshell", () => {
+    const cmds = extractGhCommands("(gh pr view 123)");
+    assert.deepStrictEqual(cmds, ["gh pr view 123"]);
+  });
+
+  it("extracts gh command from command substitution", () => {
+    const cmds = extractGhCommands("echo $(gh pr view 1 --json number)");
+    assert.deepStrictEqual(cmds, ["gh pr view 1 --json number"]);
+  });
+
+  it("returns empty for commands without gh", () => {
+    const cmds = extractGhCommands("cd /path && ls");
+    assert.deepStrictEqual(cmds, []);
+  });
+});
+
+describe("validateGhCommands", () => {
+  it("allows valid compound command", () => {
+    const result = validateGhCommands("cd /path && gh pr create --title 'Test'");
+    assert.strictEqual(result.allowed, true);
+  });
+
+  it("allows multiple valid gh commands", () => {
+    const result = validateGhCommands("gh pr list && gh issue list");
+    assert.strictEqual(result.allowed, true);
+  });
+
+  it("blocks if any gh command is invalid", () => {
+    const result = validateGhCommands("gh pr list && gh pr merge 1");
+    assert.strictEqual(result.allowed, false);
+  });
+
+  it("blocks dangerous commands in compound statements", () => {
+    const result = validateGhCommands("cd /path && gh repo delete owner/repo");
+    assert.strictEqual(result.allowed, false);
+  });
+});


### PR DESCRIPTION
Detect and validate gh commands after shell operators (`&&`, `;`, `||`) and in subshells/command substitutions. All embedded gh commands are validated against the allow-list before the compound statement runs with `GH_CONFIG_DIR` set.

Fixes #37

## Changes
- `containsGhCommand()` - detects gh anywhere in a command
- `extractGhCommands()` - extracts all gh invocations from compound statements  
- `validateGhCommands()` - validates each extracted command against allow-list
- Updated bash tool intercept to use `containsGhCommand()` instead of `startsWith('gh ')`
- Added tests for new functions