### PR TITLE
Add profile loading extension

### DIFF
--- a/extensions/collaboration.ts
+++ b/extensions/collaboration.ts
@@ -1,0 +1,87 @@
+/**
+ * Collaboration framework extension.
+ * 
+ * - --profile <name>: Load a profile into the system prompt at session start
+ * - get_model tool: Returns current model identifier for profile provenance
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+
+// Find profiles directory relative to this extension
+const extensionDir = dirname(import.meta.url.replace("file://", ""));
+const repoRoot = join(extensionDir, "..");
+const profilesDir = join(repoRoot, "profiles");
+
+export default function (pi: ExtensionAPI) {
+  // Register --profile flag
+  pi.registerFlag("profile", {
+    description: "Load a collaboration profile into the system prompt",
+    type: "string",
+  });
+
+  let profileContent: string | null = null;
+
+  // Load profile at session start
+  pi.on("session_start", async (_event, ctx) => {
+    // CLI flag takes precedence
+    let profileName = pi.getFlag("--profile") as string | undefined;
+
+    // Otherwise, prompt for selection if profiles exist
+    if (!profileName && ctx.hasUI) {
+      const profiles = readdirSync(profilesDir)
+        .filter((f) => f.endsWith(".md"))
+        .map((f) => f.replace(/\.md$/, ""));
+
+      if (profiles.length === 0) return;
+
+      if (profiles.length === 1) {
+        profileName = profiles[0];
+      } else {
+        const selected = await ctx.ui.select("Select profile:", ["(none)", ...profiles]);
+        if (!selected || selected === "(none)") return;
+        profileName = selected;
+      }
+    }
+
+    if (!profileName) return;
+
+    const profilePath = join(profilesDir, `${profileName}.md`);
+    if (!existsSync(profilePath)) {
+      ctx.ui.notify(`Profile not found: ${profilePath}`, "error");
+      return;
+    }
+
+    profileContent = readFileSync(profilePath, "utf-8");
+    ctx.ui.setStatus("profile", ctx.ui.theme.fg("success", `profile: ${profileName}`));
+  });
+
+  // Inject profile into system prompt
+  pi.on("before_agent_start", async (event, _ctx) => {
+    if (!profileContent) return;
+
+    return {
+      systemPrompt: event.systemPrompt + "\n\n" + profileContent,
+    };
+  });
+
+  // Tool to get model info for profile generation
+  pi.registerTool({
+    name: "get_model",
+    label: "Get Model",
+    description: "Returns the current model identifier for profile provenance frontmatter",
+    parameters: Type.Object({}),
+    async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
+      const model = ctx.model;
+      const id = `${model.provider}/${model.id}`;
+      const timestamp = new Date().toISOString().split("T")[0];
+
+      return {
+        content: [{ type: "text", text: `model: ${id}\ngenerated: ${timestamp}` }],
+        details: { provider: model.provider, id: model.id, timestamp },
+      };
+    },
+  });
+}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,5 @@
   "scripts": {
     "test": "node --test extensions/gh-agent/test/*.test.ts --experimental-strip-types"
   },
-  "keywords": ["pi-package"],
-  "pi": {
-    "extensions": ["./extensions"]
-  }
+  "keywords": ["pi-package"]
 }

--- a/profiles/refine-framework.md
+++ b/profiles/refine-framework.md
@@ -1,0 +1,70 @@
+---
+model: anthropic/claude-opus-4-5
+generated: 2026-02-18
+source-concepts:
+  - model-refinement
+---
+
+# Refine Collaboration Framework
+
+Collaborate on refining concepts in this framework.
+
+## Context
+
+This is a collaboration framework built on six truths. The key one for this work:
+
+**T-6**: Expressed intent is lossy. You must infer my intent from expression, not treat expression as intent.
+
+## Vocabulary
+
+- **Concepts**: Freeform markdown in `concepts/`. Source of truth for what I mean.
+- **Profiles**: Compressed from concepts for specific targets. Generated, validated, committed.
+- **`[[concept]]`**: Reference to `concepts/concept.md`
+
+## The Loop
+
+When I observe friction—something doesn't land right—we refine:
+
+1. Is the concept unclear? → Edit the concept
+2. Is a concept missing? → Create one
+3. Should something be extracted? → Split into referenced concept
+
+## How to Help
+
+- When I describe friction, help me locate whether it's concept-level or expression-level
+- Propose concept edits as diffs I can accept or refine
+- Notice when I'm repeating ideas across concepts—suggest extraction
+- Ask "what do you actually mean?" when my expression seems lossy
+
+---
+
+## Concepts
+
+### Model Refinement
+
+Models are tools for reasoning. They simplify reality so you can act on it. But simplification means incompleteness — every model is wrong somewhere.
+
+The goal isn't a perfect model. It's a model that serves your purpose well enough that you stop noticing friction.
+
+#### The Loop
+
+When observation contradicts your model, you have two choices:
+
+1. Dismiss the observation (maybe it's noise)
+2. Update the model (maybe it's signal)
+
+Neither is always right. But if the same friction keeps showing up, that's signal. Update the model.
+
+This applies at every level:
+- A mental model of how someone communicates
+- A concept in this framework
+- A codebase's architecture
+- An assumption about what a user wants
+
+The structure is the same: observe, notice friction, decide if it's signal, refine if it is.
+
+#### When to Stop
+
+You stop when the model stops failing in ways you care about. "Good enough" is subjective and contextual — only you know when you've hit it.
+
+Premature optimization of models is as real as premature optimization of code. Refine when friction demands it, not before.


### PR DESCRIPTION
Adds a pi extension for loading collaboration profiles into the system prompt.

## What's included

- `extensions/collaboration.ts` — Profile loading extension
- `profiles/refine-framework.md` — First profile for iterating on the framework

## Features

- `--profile <name>` flag to load a specific profile
- Interactive profile selector on new sessions (when multiple profiles exist)
- `get_model` tool for deterministic profile provenance in frontmatter
- Profile shown in footer status bar

## Installation

Extensions are installed independently by path:

```bash
pi install /path/to/collaboration-framework/extensions/collaboration.ts
```

## Usage

```bash
# Explicit profile
pi --profile refine-framework

# Or select interactively on session start
pi
```

## Notes

- Removed `pi.extensions` from package.json so extensions don't bundle together
- gh-agent remains separate, installable via its own path