### PR TITLE
best-practices: verify before submitting

### DIFF
--- a/concepts/best-practices.md
+++ b/concepts/best-practices.md
@@ -3,3 +3,5 @@ When working in a domain, follow its established best practices.
 I'm not encoding specifics here — they're well-known and you know them. I'm encoding that I care about following them.
 
 If a practice is domain-standard, do it. If you're unsure whether something is standard, ask.
+
+One specific: verify before submitting. Run tests, linters, type checks — whatever the project uses. If it fails, fix it first.


### PR DESCRIPTION
Adds one specific to best-practices: run tests/linters/type checks before submitting code.

**Why:** PR #59 shipped with failing tests—the allow-list changed but tests still asserted the old behavior. This was caught in review, but shouldn't have made it that far.

**Change:**
```
One specific: verify before submitting. Run tests, linters, type checks — whatever the project uses. If it fails, fix it first.
```

This is specific where the rest of best-practices is abstract, but it's universal across code domains and we just hit it.