### PR TITLE
best-practices: sync before branching

### DIFF
--- a/concepts/best-practices.md
+++ b/concepts/best-practices.md
@@ -5,3 +5,5 @@ I'm not encoding specifics here — they're well-known and you know them. I'm en
 If a practice is domain-standard, do it. If you're unsure whether something is standard, ask.
 
 One specific: verify before submitting. Run tests, linters, type checks — whatever the project uses. If it fails, fix it first.
+
+Another: sync before branching. Pull the latest from the base branch first. Stale starts cause avoidable conflicts.


### PR DESCRIPTION
Adds another specific to best-practices: pull latest from base branch before creating a new branch.

**Why:** When about to create the allow-list PR for issue #61, you asked if I would have pulled first. I wouldn't have. Same category as verify-before-submit—basic hygiene that's easy to skip.

**Change:**
```
Another: sync before branching. Pull the latest from the base branch first. Stale starts cause avoidable conflicts.
```