### PR TITLE
gh-agent: allow requesting reviewers on PRs

### DIFF
--- a/extensions/gh-agent/allow-list.ts
+++ b/extensions/gh-agent/allow-list.ts
@@ -38,6 +38,8 @@ const ALLOWED_API_PATTERNS = [
   "repos/*/*/issues/comments/*",
   // Edit PR review comments
   "repos/*/*/pulls/comments/*",
+  // Request reviewers on PRs
+  "repos/*/*/pulls/*/requested_reviewers",
 ] as const;
 
 /** HTTP methods allowed per API pattern type */
@@ -45,6 +47,7 @@ const API_METHOD_RULES: Record<string, string[]> = {
   "/replies": ["POST"],
   "/issues/comments/": ["GET", "PATCH"],
   "/pulls/comments/": ["GET", "PATCH"],
+  "/requested_reviewers": ["POST"],
 };
 
 export type ValidationResult =

--- a/extensions/gh-agent/test/allow-list.test.ts
+++ b/extensions/gh-agent/test/allow-list.test.ts
@@ -175,6 +175,20 @@ describe("isAllowed", () => {
       assert.strictEqual(result.allowed, false);
     });
 
+    it("allows requesting reviewers (POST)", () => {
+      const result = isAllowed(
+        'gh api repos/owner/repo/pulls/59/requested_reviewers -X POST -f reviewers[]="dyreby"'
+      );
+      assert.strictEqual(result.allowed, true);
+    });
+
+    it("blocks requesting reviewers with wrong method", () => {
+      const result = isAllowed(
+        "gh api repos/owner/repo/pulls/59/requested_reviewers -X DELETE"
+      );
+      assert.strictEqual(result.allowed, false);
+    });
+
     it("blocks arbitrary API endpoints", () => {
       const result = isAllowed("gh api repos/owner/repo/collaborators");
       assert.strictEqual(result.allowed, false);


### PR DESCRIPTION
## Summary

Adds `repos/*/*/pulls/*/requested_reviewers` (POST) to the gh-agent API allow-list.

Closes #61

## Why

After addressing review feedback on PR #59, I couldn't re-request review—had to tell you to do it manually. Requesting reviewers is a natural part of the collaboration workflow.

## Changes

- Added endpoint pattern to `ALLOWED_API_PATTERNS`
- Added POST method rule for `/requested_reviewers`
- Added tests (2 new: allows POST, blocks DELETE)