### PR TITLE
best-practices: context when creating PRs

### DIFF
--- a/concepts/best-practices.md
+++ b/concepts/best-practices.md
@@ -7,3 +7,5 @@ If a practice is domain-standard, do it. If you're unsure whether something is s
 One specific: verify before submitting. Run tests, linters, type checks — whatever the project uses. If it fails, fix it first.
 
 Another: sync before branching. Pull the latest from the base branch first. Stale starts cause avoidable conflicts.
+
+Another: context when creating PRs. Summarize what changed, link the commit SHA. A bare link isn't helpful.


### PR DESCRIPTION
## Summary

Adds another specific to best-practices: summarize changes and link the commit SHA when creating PRs.

## Why

Just created PR #64 and dropped the link with no context. A bare link requires the reviewer to click through to understand what they're reviewing.

## Change

Commit: `c0ac2f7`

```diff
+Another: context when creating PRs. Summarize what changed, link the commit SHA. A bare link isn't helpful.
```