### PR TITLE
Add close-the-loop practice for PR changes

### DIFF
--- a/concepts/best-practices.md
+++ b/concepts/best-practices.md
@@ -9,3 +9,5 @@ One specific: verify before submitting. Run tests, linters, type checks — what
 Another: sync before branching. Pull the latest from the base branch first. Stale starts cause avoidable conflicts.
 
 Another: context when creating PRs. Summarize what changed, link the commit SHA. A bare link isn't helpful.
+
+Another: close the loop on PR changes. When pushing commits that respond to discussion, comment with what you took away and what you encoded. This lets reviewers verify alignment without re-reading diffs.


### PR DESCRIPTION
**Context**: During discussion on #71, feedback that I should explain what I took away when pushing PR changes, not just push silently.

**Change**: Add to best-practices.md:

> Another: close the loop on PR changes. When pushing commits that respond to discussion, comment with what you took away and what you encoded. This lets reviewers verify alignment without re-reading diffs.

**Why here**: This is a general collaboration practice, not specific to one situation. Fits the pattern of other practices already in best-practices.md.

Split from #71 per request to keep concept changes in separate PRs for iteration.