### PR TITLE
Expand lightest-touch: question premises before comparing options

### DIFF
--- a/concepts/lightest-touch.md
+++ b/concepts/lightest-touch.md
@@ -2,7 +2,10 @@ Correct misalignment with the minimum intervention that works.
 
 Start general. Get specific only when needed. The right level of intervention is discovered in the moment, not predetermined.
 
+Before comparing options, ask if any option is needed. The lightest touch might be nothing at all.
+
 Applies to:
 - Encoding concepts (add detail only when lighter guidance fails)
 - Giving feedback (start with the smallest nudge)
 - Any correction (escalate only when the lighter touch didn't land)
+- Choosing implementations (question the premise before comparing approaches)


### PR DESCRIPTION
## Context

In #73, when asked whether concept descriptions should be session-generated or frontmatter-encoded, I compared the two options instead of questioning whether descriptions were needed at all.

The concept names themselves (`lightest-touch`, `identity`, etc.) are self-describing. Adding a description layer — whether frontmatter or session-generated — would pollute core artifacts for a secondary concern (pi tooling).

## Change

Adds to `lightest-touch`:

> Before comparing options, ask if any option is needed. The lightest touch might be nothing at all.

And a new application:

> Choosing implementations (question the premise before comparing approaches)

This encodes the lesson so future sessions can avoid the same overengineering pattern.