### PR TITLE
Implement concept activation (replaces broken profile loading)

### DIFF
--- a/extensions/collaboration.ts
+++ b/extensions/collaboration.ts
@@ -20,7 +20,7 @@ This context uses concepts from the collaboration framework.
 
 [[cf:name]] is a provenance marker—it means the concept "name" (from concepts/name.md) was referenced when writing this text. The marker indicates influence, not inclusion; the referenced concept's full content isn't necessarily in context.
 
-On misalignment (inferred, detected, or reported by the user): load any linked [[cf:]] concepts fully into context via /concept, then enter a concept_alignment loop with the user to resolve the gap.
+On misalignment (inferred, detected, or reported by the user): load any linked [[cf:]] concepts fully into context via /concept, then enter a [[cf:concept-alignment]] loop with the user to resolve the gap.
 </collaboration-framework>`;
 
 export default function (pi: ExtensionAPI) {


### PR DESCRIPTION
## Summary

Replaces the broken profile-based extension with concept activation per RFC-08/ADR-08.

## Changes

- **`/concept` command**: Fuzzy picker showing all concepts with active state (● active, ○ inactive). Toggle on/off.
- **System prompt injection**: Preamble explaining `[[cf:]]` syntax + concatenated active concept contents
- **Status indicator**: Shows active concepts in footer (e.g., `concepts: truths, lightest-touch`)
- **Removed `get_model` tool**: Provenance is handled by git history; the author validates the content, not the tool that helped write it
- **Removed `--profile` flag**: Replaced by dynamic `/concept` command

## Testing

1. `pi -e extensions/collaboration.ts`
2. Type `/concept`
3. Select a concept to activate
4. Verify status shows active concept
5. Send a message and verify concept is in context

Closes #73

Commit: b6efee4