### PR TITLE
fix: add consistency-boundary extension to pi manifest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,14 @@ Expectation alignment (concepts, profiles) flows through issues and PRs. Structu
 
 **Profiles** — Precise. Compressed for purpose. Match the context they'll be used in.
 
+## Extensions
+
+When adding a new extension, add it to `pi.extensions` in `package.json`. The manifest is explicit so users know what they're installing. We may publish to npm or JSR eventually, but for now installation is through git:
+
+```bash
+pi install git:github.com/dyreby/collaboration-framework
+```
+
 ## For Others
 
 If you see something that doesn't make sense, please open an issue. I'll explain my reasoning or realize I need to clarify.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "pi": {
     "extensions": [
       "./extensions/collaboration.ts",
+      "./extensions/consistency-boundary.ts",
       "./extensions/gh-agent"
     ]
   }


### PR DESCRIPTION
The `consistency-boundary.ts` extension was missing from the `pi.extensions` array in `package.json`, so it wasn't loaded when installing the package via `pi install git:dyreby/collaboration-framework`.

**Root cause:** When adding new extensions to `extensions/`, the `package.json` manifest wasn't updated accordingly.