### PR TITLE
Clarify: link commits when iterating on PRs, not creating

### DIFF
--- a/concepts/best-practices.md
+++ b/concepts/best-practices.md
@@ -8,8 +8,6 @@ One specific: verify before submitting. Run tests, linters, type checks — what
 
 Another: sync before branching. Pull the latest from the base branch first. Stale starts cause avoidable conflicts.
 
-Another: context when creating PRs. Summarize what changed.
-
 Another: close the loop on PR changes. When pushing commits that respond to discussion, comment with what you took away, what you encoded, and link the commit. This lets reviewers verify alignment without re-reading diffs.
 
 Another: confirm before external actions. Showing a change is different from pushing it. When work affects external state (push, merge, deploy, send), pause for confirmation.


### PR DESCRIPTION
Move 'link the commit SHA' guidance from PR creation to PR iteration.

When creating a PR, the PR itself links to commits. Linking a SHA is useful when responding to review feedback—so reviewers can verify which commit addressed their comment.