### PR TITLE
Add notifications API and search issues to gh-agent allow list

### DIFF
--- a/extensions/gh-agent/allow-list.ts
+++ b/extensions/gh-agent/allow-list.ts
@@ -31,10 +31,13 @@ const ALLOWED_COMMANDS = [
 
   // Search
   "search prs",
+  "search issues",
 ] as const;
 
 /** Allowed API endpoint patterns (supports * wildcards for single path segments) */
 const ALLOWED_API_PATTERNS = [
+  // Notifications - see what needs attention across all repos
+  "notifications",
   // List PR review comments
   "repos/*/*/pulls/*/comments",
   // Reply to inline PR comments

--- a/extensions/gh-agent/test/allow-list.test.ts
+++ b/extensions/gh-agent/test/allow-list.test.ts
@@ -74,6 +74,11 @@ describe("isAllowed", () => {
       assert.strictEqual(result.allowed, true);
     });
 
+    it("allows search issues", () => {
+      const result = isAllowed("gh search issues --mentions=john-agent --state=open");
+      assert.strictEqual(result.allowed, true);
+    });
+
     it("allows issue close", () => {
       const result = isAllowed("gh issue close 123");
       assert.strictEqual(result.allowed, true);
@@ -133,6 +138,16 @@ describe("isAllowed", () => {
   });
 
   describe("API commands", () => {
+    it("allows notifications (GET)", () => {
+      const result = isAllowed("gh api notifications");
+      assert.strictEqual(result.allowed, true);
+    });
+
+    it("allows notifications with query params", () => {
+      const result = isAllowed("gh api notifications --jq '.[] | select(.reason == \"review_requested\")'");
+      assert.strictEqual(result.allowed, true);
+    });
+
     it("allows listing PR review comments (GET)", () => {
       const result = isAllowed("gh api repos/owner/repo/pulls/1/comments");
       assert.strictEqual(result.allowed, true);


### PR DESCRIPTION
## Summary

Adds two capabilities to the gh-agent extension:

1. **`gh api notifications`** - Allows checking GitHub notifications to see what needs attention across all repos (review requests, mentions, PR comments, etc.)

2. **`gh search issues`** - Allows searching issues across repos (useful for finding mentions)

## Motivation

Without access to the notifications API, the agent can't efficiently check where attention is needed and has to run multiple fragmented searches. The notifications endpoint is read-only (GET) and aggregates:
- PRs authored that have new reviews/comments
- Review requests
- @mentions
- Assignments
- Subscriptions

## Changes

- `allow-list.ts`: Added `notifications` to `ALLOWED_API_PATTERNS` and `search issues` to `ALLOWED_COMMANDS`
- `allow-list.test.ts`: Added tests for both additions

## Testing

All 65 tests pass.