### PR TITLE
Allow fetching PR reviews in gh-agent

### DIFF
--- a/extensions/gh-agent/allow-list.ts
+++ b/extensions/gh-agent/allow-list.ts
@@ -38,6 +38,8 @@ const ALLOWED_COMMANDS = [
 const ALLOWED_API_PATTERNS = [
   // Notifications - see what needs attention across all repos
   "notifications",
+  // List PR reviews (contains review body and state)
+  "repos/*/*/pulls/*/reviews",
   // List PR review comments
   "repos/*/*/pulls/*/comments",
   // Reply to inline PR comments


### PR DESCRIPTION
Add `repos/*/*/pulls/*/reviews` to the allow list so we can read review feedback (body text and state like `approved`/`changes_requested`).

Fixes #84