### PR TITLE
fix: clarify that concepts should be understood from names, not eagerly loaded

### DIFF
--- a/extensions/collaboration.ts
+++ b/extensions/collaboration.ts
@@ -18,7 +18,9 @@ const conceptsDir = join(repoRoot, "concepts");
 const PREAMBLE = `<collaboration-framework>
 This context uses concepts from the collaboration framework.
 
-[[cf:name]] is a provenance marker—it means the concept "name" (from concepts/name.md) was referenced when writing this text. Concept names are semantically meaningful: "best-practices" means what you'd expect. The marker indicates influence, not inclusion; the file contains specifics and refinements, not a different meaning. If unsure whether your understanding aligns, load the concept via /concept.
+[[cf:name]] is a provenance marker—it means the concept "name" (from concepts/name.md) was referenced when writing this text. Concept names are semantically meaningful: "best-practices" means what you'd expect. The marker indicates influence, not inclusion; the file contains specifics and refinements, not a different meaning.
+
+You're expected to understand concepts from their names. Load the file only when uncertain or when misalignment occurs.
 
 Always apply [[cf:best-practices]].
 


### PR DESCRIPTION
## Problem

The preamble says "Always apply [[cf:best-practices]]" which can be misinterpreted as an imperative to load and follow the documented concept file at session start.

This happened in practice: when asked whether the preamble should include file paths (like Pi's documentation section does), I interpreted "always apply" as meaning I should actively read the best-practices file—contradicting the preamble's own statement that concept names are semantically meaningful and files contain "specifics and refinements, not a different meaning."

## Solution

Add explicit guidance that concepts should be understood from their names, with files loaded only when uncertain or when misalignment occurs:

> You're expected to understand concepts from their names. Load the file only when uncertain or when misalignment occurs.

This primes the correct interpretation of "Always apply [[cf:best-practices]]"—use your understanding of best practices, don't go read the file.

## Context

Discovered during a session where we discussed whether the collaboration framework section should include file paths. The friction revealed that the preamble's intent wasn't landing correctly.