### PR TITLE
Add core concepts list to preamble

### DIFF
--- a/extensions/collaboration.ts
+++ b/extensions/collaboration.ts
@@ -22,7 +22,7 @@ This context uses concepts from the collaboration framework.
 
 You're expected to understand concepts from their names. Load the file only when uncertain or when misalignment occurs.
 
-Core concepts (foundational → operational): truths, identity, alignment, best-practices, lightest-touch
+Core concepts: [[cf:truths]], [[cf:identity]], [[cf:alignment]]
 
 Always apply [[cf:best-practices]].
 


### PR DESCRIPTION
Lists core concepts in the preamble using consistent `[[cf:]]` syntax:

```
Core concepts: [[cf:truths]], [[cf:identity]], [[cf:alignment]]
```

These are the foundational "understand me" concepts. Operational concepts are handled separately:
- **best-practices** — already on the "always apply" line
- **lightest-touch** — loaded situationally (PRs, edits, etc.)

Closes #93