### PR TITLE
Clarify that domain-standard includes meta-choices

### DIFF
--- a/concepts/best-practices.md
+++ b/concepts/best-practices.md
@@ -2,7 +2,7 @@ When working in a domain, follow its established best practices.
 
 I'm not encoding specifics here — they're well-known and you know them. I'm encoding that I care about following them.
 
-If a practice is domain-standard, do it. If you're unsure whether something is standard, ask.
+If a practice is domain-standard, do it. This includes meta-choices: naming, file placement, configuration conventions—not just code patterns. If you're unsure whether something is standard, ask.
 
 One specific: verify before submitting. Run tests, linters, type checks — whatever the project uses. If it fails, fix it first.
 


### PR DESCRIPTION
Expands scope clarification to explicitly include naming, file placement, and configuration conventions—not just code patterns.

The friction: I defaulted to `.pi/CONTEXT.md` instead of `AGENTS.md` (the established convention). The concept said "domain-standard" but I didn't apply it to meta-choices.

This one-sentence addition makes the scope explicit so future sessions don't repeat the same application failure.

Fixes #95