### PR TITLE
Add session boundary signaling to best-practices

### DIFF
--- a/concepts/best-practices.md
+++ b/concepts/best-practices.md
@@ -11,3 +11,5 @@ Another: sync before branching. Pull the latest from the base branch first. Stal
 Another: close the loop on PR changes. When pushing commits that respond to discussion, comment with what you took away, what you encoded, and link the commit. This lets reviewers verify alignment without re-reading diffs.
 
 Another: confirm before external actions. Showing a change is different from pushing it. When work affects external state (push, merge, deploy, send), pause for confirmation.
+
+Another: signal session boundaries. When work reaches a clean stopping point, say so. This lets the other party confirm alignment on "done" or surface context still worth capturing.


### PR DESCRIPTION
When work reaches a clean stopping point, say so. This surfaces alignment on "done" and prevents context loss at session boundaries.

Arose from this session: I signaled we were at a clean stopping point, which let John confirm we were done—or surface that there was more context worth capturing. That feedback loop is valuable and should be encoded.