### PR TITLE
Reconcile concepts with README language

### DIFF
--- a/concepts/alignment.md
+++ b/concepts/alignment.md
@@ -4,11 +4,17 @@ Alignment is agreement on what we're doing and why. Perfect alignment between ag
 
 ## The Structure
 
-Alignment is hierarchical. "What are we trying to do?" comes before "How do we do it?" But every "how" becomes a "what" for the next level down. The pattern recurses.
+Alignment is hierarchical: *why* → *what* → *how*. And each *how* contains its own why/what/how, all the way down.
 
 At the top: a shared objective. Below that: agreement on approach. Below that: agreement on implementation. All the way down to tabs vs. spaces.
 
 At each level, alignment looks the same: each agent says "I think we should do it this way, and here's why." Then we agree—or surface that we don't.
+
+**Over-alignment creates noise.** A junior developer doesn't need the CEO's full strategic context, and couldn't use it. The right level for them is: this feature matters, build it well.
+
+**Under-alignment creates gaps.** A developer who doesn't know *why* a feature matters will make poor tradeoffs when edge cases appear.
+
+**The right level is discovered, not prescribed.** Step back to obvious agreement, then step down until we find where the work lives. That's where the work becomes light.
 
 ## Signs of Alignment
 

--- a/concepts/truths.md
+++ b/concepts/truths.md
@@ -10,6 +10,6 @@ T-3: Agents use their world models to select actions in pursuit of objectives.
 
 T-4: World input and model-derived conclusions are distinct. World input is taken as given.
 
-T-5: Required context is the gap between agent understanding and situation requirements.
+T-5: Collaboration adds context that agents can't derive alone, including the intent of the collaborator.
 
 T-6: Expressed intent is lossy. Infer intent from expression, do not treat expression as intent.


### PR DESCRIPTION
The README was refined with clearer framings that hadn't been backported to concepts.

**Changes:**

**alignment.md:**
- why → what → how hierarchy (was just 'what before how')
- Over/under-alignment framing
- 'The right level is discovered, not prescribed'

**truths.md:**
- T-5 now matches philosophy.md: 'Collaboration adds context that agents can't derive alone, including the intent of the collaborator'
- (was: 'Required context is the gap between agent understanding and situation requirements')

No architectural change—just reconciling language to match established intent.