### PR TITLE
Use 'work together' instead of 'collaborate' in intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Collaboration Framework
 
-A framework for encoding how I think, so we can collaborate effectively.
+A framework for encoding how I think, so we can work together effectively.
 
 ## The Gap
 


### PR DESCRIPTION
Changes:

> so we can collaborate effectively

to:

> so we can work together effectively

'Collaborate' is jargon-y. 'Work together' says the same thing more plainly.