### PR TITLE
Simplify collaboration preamble

### DIFF
--- a/extensions/collaboration.ts
+++ b/extensions/collaboration.ts
@@ -16,13 +16,8 @@ const repoRoot = join(extensionDir, "..");
 const conceptsDir = join(repoRoot, "concepts");
 
 const PREAMBLE = `<collaboration-framework>
-This context uses concepts from the collaboration framework.
-
-[[cf:name]] is a provenance marker—it means the concept "name" (from concepts/name.md) was referenced when writing this text. Concept names are semantically meaningful: "best-practices" means what you'd expect. The marker indicates influence, not inclusion; the file contains specifics and refinements, not a different meaning.
-
-You're expected to understand concepts from their names. Load the file only when uncertain or when misalignment occurs.
-
-On misalignment (inferred, detected, or reported by the user): load any linked [[cf:]] concepts fully into context via /concept, then enter a [[cf:concept-alignment]] loop with the user to resolve the gap.
+[[cf:name]] is a provenance marker — it references a shared concept (concepts/name.md).
+Concept names are semantically meaningful. The file contains specifics for alignment conversations.
 </collaboration-framework>
 
 Apply [[cf:best-practices]].`;


### PR DESCRIPTION
- Remove redundant 'Core concepts' line — concept names are semantically meaningful (as stated in the preamble), so listing them without requiring them to be loaded is noise. Also removes reference to deleted `identity` concept.
- Remove 'Always' from best-practices directive — everything in a system prompt is implicitly 'always'.