### PR TITLE
fix(midwest-goodbye): trigger turn immediately on /bye

### DIFF
--- a/extensions/midwest-goodbye.ts
+++ b/extensions/midwest-goodbye.ts
@@ -69,7 +69,7 @@ If something might be worth capturing (one or two sentences max):
 
 Meta: if we OODA'd, that's a calibration signal. Was it worth stopping? If yes, the extension did its job—no changes needed. If not, what would have made this a clean goodbye? Surface that.`,
         display: false,
-      });
+      }, { triggerTurn: true });
     },
   });
 }


### PR DESCRIPTION
Without `triggerTurn: true`, `sendMessage` queued the prompt but didn't invoke the model until the next user message arrived.

This caused `/bye` to appear to do nothing — the reflection only showed up after typing something else.