### PR TITLE
RFC-09: Nested OODA Context System

### DIFF
--- a/docs/rfcs/rfc-09-nested-ooda-context-system.md
+++ b/docs/rfcs/rfc-09-nested-ooda-context-system.md
@@ -11,7 +11,7 @@ A model for agent context management built on nested OODA loops: align on what c
 
 ### The Problem
 
-LLMs are powerful but fragile in large codebases:
+LLMs are powerful but can be fragile and unpredictable in large codebases:
 
 - **Too much context**: Attention dilutes, recency bias dominates, solutions converge prematurely
 - **Too little context**: Hallucination, missed cross-cutting concerns, local optimization
@@ -32,7 +32,7 @@ The gap exists at two moments:
 1. **Orient**: When the agent expresses what context it thinks it needs
 2. **Decide**: When the agent expresses what action it thinks it should take
 
-Both are lossy expressions of the agent's internal model. Both benefit from alignment before proceeding.
+Both are lossy expressions of the agent's internal model—and the user's intent that triggered the task may itself be lossy. Both benefit from alignment before proceeding.
 
 ## Core Model
 
@@ -84,7 +84,7 @@ Global (user-level)
 
 Task Types (universal)
   └─ review_pr, create_pr, create_issue, investigate, implement, refactor
-  └─ Each has default behaviors and DoD templates
+  └─ Each has default behaviors and Definition of Done (DoD) templates
 
 Project (repo-level, optional)
   └─ Overrides/extends task-type defaults


### PR DESCRIPTION
## Summary

Proposes a model for agent context management built on nested OODA loops:
- Align on what context is needed (Orient)
- Align on what action to take (Decide)

Both alignment moments follow the same structure and can evolve independently as trust builds.

## Key Ideas

1. **Make agent reasoning observable** before it acts
2. **Catch the gap early** — context request is a lossy expression of understanding
3. **Context expands intentionally** — single gateway, every expansion justified
4. **Hierarchy without rigidity** — global → task-type → project-specific
5. **Start simple, learn, improve** — both inner loops collapse as trust builds

## Supersedes

Closes #82, #113, #115 — the underlying question ("how does the agent get the right context?") is answered through task-driven OODA loops rather than manual concept loading.

## Open Questions

Captured in the RFC for discovery through implementation.