### PR TITLE
Make GitHub confirmation modal larger (80% width)

### DIFF
--- a/extensions/github/gh-command.ts
+++ b/extensions/github/gh-command.ts
@@ -389,7 +389,13 @@ async function showConfirmModal(
         },
       };
     },
-    { overlay: true }
+    {
+      overlay: true,
+      overlayOptions: {
+        width: "80%",
+        anchor: "center",
+      },
+    }
   );
 }
 


### PR DESCRIPTION
The modal is the primary focus when displayed—give it more screen space.