### PR TITLE
ADR-09: Normalize format

### DIFF
--- a/docs/adrs/adr-09-truths-to-propositions.md
+++ b/docs/adrs/adr-09-truths-to-propositions.md
@@ -1,8 +1,7 @@
 # ADR-09: Truths to Propositions
 
-## Status
-
-Accepted
+- **Status:** Accepted
+- **Date:** 2026-02-22
 
 ## Context
 


### PR DESCRIPTION
Normalize ADR-09 format to match other ADRs:

- Use bullet-point metadata style (`- **Status:** Accepted`)
- Add date field

Content unchanged—presentation only.