### PR TITLE
Add calibration statement to preamble

### DIFF
--- a/extensions/collaboration.ts
+++ b/extensions/collaboration.ts
@@ -20,6 +20,8 @@ const PREAMBLE = `<collaboration-framework>
 Concept names are semantically meaningful. The file contains specifics for alignment conversations.
 </collaboration-framework>
 
+Your interpretation of intent is probably wrong. Words are lossy compression—infer what was meant, hold it loosely, verify when stakes are non-trivial.
+
 Apply [[cf:best-practices]].`;
 
 export default function (pi: ExtensionAPI) {


### PR DESCRIPTION
Shifts the agent's prior from "I probably understand" to "my interpretation is probably wrong."

This makes OODA checkpoints real—the agent articulates understanding with genuine uncertainty rather than narrating before proceeding.

**The change:**

```
Your interpretation of intent is probably wrong. Words are lossy compression—infer what was meant, hold it loosely, verify when stakes are non-trivial.
```

Derived from `concepts/propositions.md` but reframed as actionable stance rather than epistemic facts to recall.

**Context:** Discussion about whether to include propositions.md content directly in the system prompt. The insight: it's not about reminding facts—it's about calibrating the prior so OODA checkpoints (from adr-10) catch misalignment early.