### PR TITLE
Make PR review format explicit

### DIFF
--- a/extensions/collaboration.ts
+++ b/extensions/collaboration.ts
@@ -272,16 +272,16 @@ A good review follows this structure:
 
 1. **Verdict**: First sentence states the outcome (Approve/Request Changes/Comment)
 2. **My Understanding**: "My understanding of this PR is that it..." — capture the intent one level up from what changed. The author should see I understood before I critique.
-3. **What I Like**: Call out what works well
+3. **What I Like**: Something genuinely clever, thoughtful, or notable (omit for straightforward PRs)
 4. **Questions**: Things I'm curious about or want clarified (omit if none)
 5. **Nits**: Minor suggestions, take-or-leave (omit if none)
 
-Always include My Understanding and What I Like. Only include Questions and Nits if there are any. Use \`###\` headers—provides structure to scan without fragmenting the flow.
+Always include My Understanding. Include What I Like only when something stands out—don't add fluff for "boring" (good) PRs that do what they say. Use \`###\` headers—provides structure to scan without fragmenting the flow.
 
 ### How This Goes (OODA)
 
 **Orient (context alignment)**
-Start here. Either propose what additional context you need (I'll confirm, challenge, or narrow), or state that you have enough and why. Make this step visible.
+Start here. Either propose what additional context you need (I'll confirm, challenge, or narrow), or state that you have enough and why. Make this step visible—it lets me inject context you wouldn't have (related discussions, background decisions) or confirm we're aligned by saying "ok."
 
 **Decide (action alignment)**
 When ready, call the \`github\` tool with your \`pr review\` command. A confirmation modal will show the review—press Enter to execute, or Escape to discuss. If you escape, I'll tell you what's on my mind, you revise, and we iterate until aligned.


### PR DESCRIPTION
Clarifies the PR review format in the `/review-pr` command template:

- Verdict as first sentence, not a header
- Use 'I' not 'we' in headers and guidance  
- 'My understanding of this PR is that it...' framing
- Questions and Nits only when present
- My Understanding and What I Like always required

This came out of reviewing oxbo PR #21 where the format needed iteration to land correctly.