### PR TITLE
Add writing-style concept

### DIFF
--- a/.pi/prompts/review-pr.md
+++ b/.pi/prompts/review-pr.md
@@ -3,6 +3,8 @@ description: Review a pull request with OODA framing
 ---
 ## Task: Review PR #$1
 
+Apply [[cf:writing-style]].
+
 ### Gather Context
 
 Use the `github` tool to fetch:

--- a/concepts/writing-style.md
+++ b/concepts/writing-style.md
@@ -1,0 +1,7 @@
+# writing-style
+
+Preferences for written communication:
+
+- **Emojis**: Sparingly. Use when they genuinely add something—a well-placed one that makes someone chuckle is worth it. Decorative checkmarks aren't.
+- **Em dashes**: Sparingly—when they clarify structure or add rhythm, not as default punctuation.
+- **Tone**: Direct, not curt. Concise, not terse.


### PR DESCRIPTION
Adds `[[cf:writing-style]]` concept for communication preferences:

- Emojis sparingly—only when they genuinely add value
- Em dashes sparingly—for structure/rhythm, not default punctuation  
- Direct but not curt tone

Referenced in `/review-pr` template so PR reviews follow these preferences.

Emerged from feedback on PR #138 where decorative checkmark emojis were flagged as noise.