### PR TITLE
Add github-preferences concept

### DIFF
--- a/concepts/github-preferences.md
+++ b/concepts/github-preferences.md
@@ -1,0 +1,7 @@
+# github-preferences
+
+Preferences for GitHub operations in dyreby/* repos:
+
+- **PR creation**: When creating a PR as john-agent, request dyreby's review.
+- **PR updates**: After pushing changes that address review feedback, re-request review.
+- **PR comments**: When addressing review feedback, leave a comment summarizing what changed and why.

--- a/extensions/github/index.ts
+++ b/extensions/github/index.ts
@@ -29,7 +29,9 @@ import { createGithubTool, type GhToolContext } from "./gh-command.ts";
 const COMMUNICATION_STYLE = `Use "I" for your own perspective. Respond to context, not to people—let the content stand without referencing other parties.`;
 
 /** Instruction to use the github tool for gh commands */
-const GITHUB_TOOL_INSTRUCTION = `For GitHub CLI operations (gh commands), use the \`github\` tool instead of bash. The github tool handles identity switching automatically.`;
+const GITHUB_TOOL_INSTRUCTION = `For GitHub CLI operations (gh commands), use the \`github\` tool instead of bash. The github tool handles identity switching automatically.
+
+Apply [[cf:github-preferences]].`;
 
 export default function (pi: ExtensionAPI) {
   let currentRepoOwner: string | null = null;


### PR DESCRIPTION
Adds `[[cf:github-preferences]]` concept for GitHub workflow preferences:

- Request dyreby's review when creating PRs as john-agent
- Re-request review after addressing feedback  
- Comment summarizing changes when addressing feedback

The github extension now includes `Apply [[cf:github-preferences]].` in its tool instruction, so the concept auto-loads via the collaboration framework's concept system.

This replaces hardcoding the behavior in extension code—preferences are documented and editable as concepts.