### PR TITLE
Reorder extension toolbar: github first, separator, then concepts

### DIFF
--- a/extensions/collaboration.ts
+++ b/extensions/collaboration.ts
@@ -122,7 +122,8 @@ export default function (pi: ExtensionAPI) {
         .map(([name, count]) => `${name}(${count})`);
       ctx.ui.setStatus(
         "concepts",
-        ctx.ui.theme.fg("success", `concepts: ${sorted.join(", ")}`)
+        ctx.ui.theme.fg("muted", "│ ") +
+          ctx.ui.theme.fg("success", `concepts: ${sorted.join(", ")}`)
       );
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "keywords": ["pi-package"],
   "pi": {
     "extensions": [
-      "./extensions/collaboration.ts",
+      "./extensions/github",
       "./extensions/midwest-goodbye.ts",
-      "./extensions/github"
+      "./extensions/collaboration.ts"
     ]
   }
 }


### PR DESCRIPTION
Changes the status bar order:
- Load github extension first (appears first in toolbar)
- Add a vertical separator (│) before concepts
- Load collaboration extension last

Result: `gh: dyreby/* → john-agent │ concepts: ...`