### PR TITLE
Use minimal thinking for /bye reflection

### DIFF
--- a/extensions/midwest-goodbye.ts
+++ b/extensions/midwest-goodbye.ts
@@ -46,6 +46,9 @@ export default function (pi: ExtensionAPI) {
       const cleanBye = pick(cleanGoodbyes);
       const oneMore = pick(oneMoreThings);
 
+      // Reflection doesn't need deep thinking
+      pi.setThinkingLevel("minimal");
+
       pi.sendMessage({
         customType: "midwest-goodbye",
         content: `The user typed /bye. Reflect on this session:


### PR DESCRIPTION
The doorknob check is a quick reflection, not a deep reasoning task.

Sets thinking level to minimal before sending the reflection prompt.