### PR TITLE
Simplify concept reference syntax from [[cf:name]] to `cf:name`

### DIFF
--- a/.pi/prompts/review-pr.md
+++ b/.pi/prompts/review-pr.md
@@ -3,7 +3,7 @@ description: Review a pull request with OODA framing
 ---
 ## Task: Review PR #$1
 
-Apply [[cf:writing-style]].
+Apply `cf:writing-style`.
 
 ### Gather Context
 

--- a/concepts/concept-alignment.md
+++ b/concepts/concept-alignment.md
@@ -1,6 +1,6 @@
 # Concept Alignment
 
-[[cf:alignment]] applied to concepts.
+`cf:alignment` applied to concepts.
 
 Concepts encode shared understanding. Each concept is a model—a simplification that makes collaboration possible. But simplification means incompleteness; every concept is wrong somewhere.
 
@@ -32,7 +32,7 @@ Premature optimization of concepts is as real as premature optimization of code.
 
 ## How to Refine
 
-Apply [[cf:lightest-touch]]—start with the smallest change that addresses the friction. Follow [[cf:best-practices]] for whatever domain the concept lives in.
+Apply `cf:lightest-touch`—start with the smallest change that addresses the friction. Follow `cf:best-practices` for whatever domain the concept lives in.
 
 ## Concept Density
 

--- a/docs/adrs/adr-12-simplified-concept-syntax.md
+++ b/docs/adrs/adr-12-simplified-concept-syntax.md
@@ -1,0 +1,70 @@
+# ADR-12: Simplified Concept Reference Syntax
+
+- **Status:** Accepted
+- **Date:** 2026-02-23
+- **Amends:** ADR-08, ADR-11 (syntax only)
+
+## Context
+
+ADR-08 established `[[cf:name]]` as the syntax for concept references, with rationale:
+
+> "The `cf:` prefix avoids collision with other `[[]]` uses (wikis, Obsidian, etc.)"
+
+ADR-11 continued this syntax for auto-loading and emphasis counting.
+
+In practice:
+1. We're not mixing with wiki tooling — the collision concern hasn't materialized
+2. The double brackets add visual noise in markdown prose
+3. A simpler syntax with backticks reads more naturally
+
+Comparing in prose:
+
+> "Apply [[cf:best-practices]] when working." — markup-heavy, interrupts reading
+> 
+> "Apply `cf:best-practices` when working." — reads like inline code annotation
+
+## Decision
+
+### Simplified Syntax
+
+Change from `[[cf:name]]` to `` `cf:name` `` (backticks required).
+
+The backticks:
+- Provide explicit boundaries (no ambiguity with punctuation)
+- Render as inline code in markdown, making references visually distinct
+- Are familiar from code/technical writing conventions
+
+The regex `` `cf:([a-zA-Z0-9_-]+)` `` matches the pattern.
+
+### Keyboard Shortcut for Insertion
+
+Add `ctrl+r` shortcut that:
+1. Shows concept picker (fuzzy searchable)
+2. Inserts `` `cf:name` `` at cursor position
+
+This aids discoverability and handles "can't remember the exact name" cases.
+
+### Preamble Update
+
+Update the system prompt preamble to document the new syntax:
+
+```
+`cf:name` is a provenance marker — it references a shared concept (concepts/name.md).
+```
+
+## Consequences
+
+### Enables
+
+- Cleaner markdown in prompts and concept files
+- Visual distinction via inline code styling
+- Quick insertion via shortcut
+
+### Constrains
+
+- Concept names must not contain characters outside `[a-zA-Z0-9_-]`
+- Backticks are required (bare `cf:name` won't be recognized)
+
+### Migration
+
+Existing `[[cf:name]]` references in concept files should be updated to `` `cf:name` ``. The old syntax will no longer be recognized.


### PR DESCRIPTION
## Summary

Changes concept reference syntax from `[[cf:name]]` to `cf:name` (backticks required) for cleaner markdown readability, and adds a keyboard shortcut for concept insertion.

## Changes

- **ADR-12**: Documents the syntax change rationale (amends ADR-08, ADR-11)
- **Regex update**:  backticks provide explicit boundaries
- **Preamble update**: Documents new syntax for LLM context
- **`/concept` description**: Updated to reflect full functionality (load, unload, boost, reduce)
- **`ctrl+r` shortcut**: Opens concept picker, inserts `\`cf:name\`` at cursor
- **Migration**: Updated existing `[[cf:...]]` references in concepts and prompts

## Rationale

From ADR-12:

> ADR-08 established `[[cf:name]]` to avoid collision with wiki syntax (Obsidian, etc.). In practice, we're not mixing with wiki tooling. The backticks provide explicit boundaries, render as inline code in markdown, and are familiar from code/technical writing conventions.

Comparison in prose:

> "Apply [[cf:best-practices]] when working." — markup-heavy, interrupts reading
>
> "Apply \`cf:best-practices\` when working." — reads like inline code annotation