### PR TITLE
Fix status bar order: github on left, concepts on right

### DIFF
--- a/extensions/github/index.ts
+++ b/extensions/github/index.ts
@@ -68,6 +68,9 @@ export default function (pi: ExtensionAPI) {
   }
 
   pi.on("session_start", async (_event, ctx) => {
+    // Set initial status immediately to establish position before async work
+    ctx.ui.setStatus("github", ctx.ui.theme.fg("muted", "gh: ..."));
+
     // Detect repo owner
     currentRepoOwner = await detectRepoOwner();
 


### PR DESCRIPTION
The github extension does async work (detecting repo, checking auth) before setting its status, while collaboration sets status synchronously. Status position is determined by first-set order, so collaboration was winning the race.

**Fix:** Set an initial placeholder status immediately in github's `session_start` handler, establishing position before the async operations complete.

**Before:** `│ concepts: github-preferences(1) gh: dyreby/* → john-agent`
**After:** `gh: dyreby/* → john-agent │ concepts: github-preferences(1)`