### PR TITLE
Remove github identity from footer, keep in modal only

### DIFF
--- a/extensions/github/index.ts
+++ b/extensions/github/index.ts
@@ -68,9 +68,6 @@ export default function (pi: ExtensionAPI) {
   }
 
   pi.on("session_start", async (_event, ctx) => {
-    // Set initial status immediately to establish position before async work
-    ctx.ui.setStatus("github", ctx.ui.theme.fg("muted", "gh: ..."));
-
     // Detect repo owner
     currentRepoOwner = await detectRepoOwner();
 
@@ -87,15 +84,7 @@ export default function (pi: ExtensionAPI) {
     if (missing.length > 0) {
       ghCtx.authError = `Auth required. Run:\n${missing.join("\n")}`;
       ctx.ui.notify(`github: ${ghCtx.authError}`, "warning");
-      return;
     }
-
-    // Show active identity
-    const account = getAccountForRepo(currentRepoOwner);
-    const label = currentRepoOwner
-      ? `${currentRepoOwner}/* → ${account}`
-      : `(no repo) → ${account}`;
-    ctx.ui.setStatus("github", ctx.ui.theme.fg("success", `gh: ${label}`));
   });
 
   // Inject communication style and github tool instruction


### PR DESCRIPTION
The footer status bar ordering was still flaky despite PR #144. Rather than continue fighting the race condition, simplify: remove the github identity from the footer entirely.

**Rationale:**
- Identity info is already shown in the confirmation modal header (e.g., "Create Pull Request as john-agent")
- That's when it actually matters—at the point of action
- Footer now just shows loaded concepts, which is cleaner

**Before:** `gh: dyreby/* → john-agent │ concepts: github-preferences(1)`
**After:** `concepts: github-preferences(1)`