### PR TITLE
github-preferences: check inline comments before merging

### DIFF
--- a/concepts/github-preferences.md
+++ b/concepts/github-preferences.md
@@ -5,3 +5,4 @@ Preferences for GitHub operations in dyreby/* repos:
 - **PR creation**: When creating a PR as john-agent, request dyreby's review.
 - **PR updates**: After pushing changes that address review feedback, re-request review.
 - **PR comments**: When addressing review feedback, leave a comment summarizing what changed and why.
+- **Before merging**: Check for approval status AND inline review comments. Approval doesn't mean "no feedback" — sometimes there are nitpicks or suggestions worth addressing first.


### PR DESCRIPTION
Adds guidance to check inline review comments before merging PRs, not just approval status.

This is a process fix — I merged PR #143 without reading the inline feedback first.