### PR TITLE
github-preferences: always use squash merge

### DIFF
--- a/concepts/github-preferences.md
+++ b/concepts/github-preferences.md
@@ -6,3 +6,4 @@ Preferences for GitHub operations in dyreby/* repos:
 - **PR updates**: After pushing changes that address review feedback, re-request review.
 - **PR comments**: When addressing review feedback, leave a comment summarizing what changed and why.
 - **Before merging**: Check for approval status AND inline review comments. Approval doesn't mean "no feedback" — sometimes there are nitpicks or suggestions worth addressing first.
+- **Merging**: Always use squash merge (`--squash`).


### PR DESCRIPTION
Adds preference to always use `--squash` when merging PRs, since merge commits are not allowed on this repo.