### PR TITLE
midwest-goodbye: restore thinking level after /bye reflection

### DIFF
--- a/extensions/midwest-goodbye.ts
+++ b/extensions/midwest-goodbye.ts
@@ -40,13 +40,24 @@ function pick<T>(list: T[]): T {
 }
 
 export default function (pi: ExtensionAPI) {
+  // Track when we need to restore thinking level after /bye reflection
+  let pendingRestore: ReturnType<typeof pi.getThinkingLevel> | null = null;
+
+  pi.on("turn_end", () => {
+    if (pendingRestore !== null) {
+      pi.setThinkingLevel(pendingRestore);
+      pendingRestore = null;
+    }
+  });
+
   pi.registerCommand("bye", {
     description: "Hand on the doorknob check",
     handler: async () => {
       const cleanBye = pick(cleanGoodbyes);
       const oneMore = pick(oneMoreThings);
 
-      // Reflection doesn't need deep thinking
+      // Reflection doesn't need deep thinking—save current level to restore after
+      pendingRestore = pi.getThinkingLevel();
       pi.setThinkingLevel("minimal");
 
       pi.sendMessage({


### PR DESCRIPTION
Save the current thinking level before changing to minimal, then restore it when the reflection turn ends.

Closes #145