### PR TITLE
fix: use placeholder syntax in preamble to avoid false concept match

### DIFF
--- a/extensions/collaboration.ts
+++ b/extensions/collaboration.ts
@@ -87,7 +87,7 @@ function loadConceptsRecursively(
 }
 
 const PREAMBLE = `<collaboration-framework>
-\`cf:name\` is a provenance marker — it references a shared concept (concepts/name.md).
+\`cf:<name>\` is a provenance marker — it references a shared concept (concepts/<name>.md).
 Concept names are semantically meaningful. The file contains specifics for alignment conversations.
 </collaboration-framework>
 


### PR DESCRIPTION
The PREAMBLE contained `cf:name` as a literal example explaining the marker syntax. This matched the concept marker regex and triggered:

```
Warning: Missing concept: name.md
```

**Fix:** Changed to `cf:<name>` — angle brackets make it clear it's a placeholder and won't match the pattern `[a-zA-Z0-9_-]+`.