### PR TITLE
github-preferences: add branching policy

### DIFF
--- a/concepts/github-preferences.md
+++ b/concepts/github-preferences.md
@@ -2,6 +2,7 @@
 
 Preferences for GitHub operations in dyreby/* repos:
 
+- **Branching**: Never commit directly to main. Always create a branch and PR for changes—even small fixes.
 - **PR creation**: When creating a PR as john-agent, request dyreby's review.
 - **PR updates**: After pushing changes that address review feedback, re-request review.
 - **PR comments**: When addressing review feedback, leave a comment summarizing what changed and why.


### PR DESCRIPTION
Adds explicit preference to never commit directly to main—always use branches and PRs, even for small fixes.