### PR TITLE
Add worktrees skill

### DIFF
--- a/skills/worktrees/SKILL.md
+++ b/skills/worktrees/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: worktrees
-description: Git worktrees for working on multiple branches or features in parallel.
+description: Git worktrees for parallel development. Use when starting new work while other work is in progress.
 ---
 
 # Git Worktree Management


### PR DESCRIPTION
Migrated from agent-stuff repo, which is being deprecated.

This skill provides conventions for managing git worktrees when working on multiple branches/PRs simultaneously.