### PR TITLE
Fix concept reference syntax in github extension

### DIFF
--- a/extensions/github/index.ts
+++ b/extensions/github/index.ts
@@ -31,7 +31,7 @@ const COMMUNICATION_STYLE = `Use "I" for your own perspective. Respond to contex
 /** Instruction to use the github tool for gh commands */
 const GITHUB_TOOL_INSTRUCTION = `For GitHub CLI operations (gh commands), use the \`github\` tool instead of bash. The github tool handles identity switching automatically.
 
-Apply [[cf:github-preferences]].`;
+Apply \`cf:github-preferences\`.`;
 
 export default function (pi: ExtensionAPI) {
   let currentRepoOwner: string | null = null;


### PR DESCRIPTION
The github extension was using the old `[[cf:github-preferences]]` syntax, which per ADR-12 has been replaced by backtick syntax (\`cf:github-preferences\`).

This caused concepts referenced by the extension to not be auto-loaded—the collaboration extension's regex only matches the backtick syntax.

**Fix:** Update to \`cf:github-preferences\`