### PR TITLE
Add explicit guidance for checking inline review comments

### DIFF
--- a/concepts/github-preferences.md
+++ b/concepts/github-preferences.md
@@ -5,6 +5,6 @@ Preferences for GitHub operations in dyreby/* repos:
 - **Branching**: Never commit directly to main. Always create a branch and PR for changes—even small fixes.
 - **PR creation**: When creating a PR as john-agent, request dyreby's review.
 - **PR updates**: After pushing changes that address review feedback, re-request review.
-- **Addressing feedback**: Check *both* PR-level comments (`github pr view --comments`) *and* inline review comments (`github api repos/{owner}/{repo}/pulls/{n}/comments`). Reply to each, summarizing what changed and why.
+- **Addressing feedback**: Check *both* PR-level comments (`github pr view --comments`) *and* inline review comments (`github api repos/{owner}/{repo}/pulls/{n}/comments`). Reply to each, summarizing what changed and why. Include the commit SHA.
 - **Before merging**: Check for approval status AND inline review comments. Approval doesn't mean "no feedback" — sometimes there are nitpicks or suggestions worth addressing first.
 - **Merging**: Always use squash merge (`--squash`).


### PR DESCRIPTION
Adds guidance for checking and responding to review feedback:

- Check *both* PR-level comments and inline review comments
- Use `github` tool (not `gh`) for the commands
- Include commit SHA when replying

---

**Merge after #161** (which adds the `--repo` guidance that should come first in the file)