### PR TITLE
Remove pipe separator from concepts status

### DIFF
--- a/extensions/collaboration.ts
+++ b/extensions/collaboration.ts
@@ -123,8 +123,7 @@ export default function (pi: ExtensionAPI) {
         .map(([name, count]) => `${name}(${count})`);
       ctx.ui.setStatus(
         "concepts",
-        ctx.ui.theme.fg("muted", "│ ") +
-          ctx.ui.theme.fg("success", `concepts: ${sorted.join(", ")}`)
+        ctx.ui.theme.fg("success", `concepts: ${sorted.join(", ")}`)
       );
     }
   }


### PR DESCRIPTION
The pipe symbol in the status bar was leftover cruft—removed it.