### PR TITLE
Include commit SHA when replying to review comments

### DIFF
--- a/concepts/github-preferences.md
+++ b/concepts/github-preferences.md
@@ -5,6 +5,6 @@ Preferences for GitHub operations in dyreby/* repos:
 - **Branching**: Never commit directly to main. Always create a branch and PR for changes—even small fixes.
 - **PR creation**: When creating a PR as john-agent, request dyreby's review.
 - **PR updates**: After pushing changes that address review feedback, re-request review.
-- **PR comments**: When addressing review feedback, leave a comment summarizing what changed and why.
+- **PR comments**: When addressing review feedback, leave a comment summarizing what changed and why. Include the commit SHA.
 - **Before merging**: Check for approval status AND inline review comments. Approval doesn't mean "no feedback" — sometimes there are nitpicks or suggestions worth addressing first.
 - **Merging**: Always use squash merge (`--squash`).


### PR DESCRIPTION
Adds guidance to include the commit SHA when replying to review feedback. Makes it easier to trace which commit addressed which comment.

Example: "Fixed—changed `gh` to `github` in both examples. (247290d)"