### PR TITLE
Fix github tool --repo flag in non-GitHub directories

### DIFF
--- a/extensions/github/gh-command.ts
+++ b/extensions/github/gh-command.ts
@@ -9,6 +9,7 @@
  * 2. Current directory's git remote
  */
 
+import { homedir } from "node:os";
 import { Type } from "@sinclair/typebox";
 import { DynamicBorder } from "@mariozechner/pi-coding-agent";
 import type {
@@ -524,9 +525,11 @@ export function createGithubTool(ctx: GhToolContext): ToolDefinition {
       }
 
       // Execute with the appropriate GH_CONFIG_DIR
+      // When --repo is specified, run from ~ to avoid cwd remote detection issues
       const fullCommand = `GH_CONFIG_DIR="${configDir}" gh ${command}`;
+      const cwd = repoFlag ? homedir() : undefined;
 
-      const result = await pi.exec("bash", ["-c", fullCommand], { signal });
+      const result = await pi.exec("bash", ["-c", fullCommand], { signal, cwd });
 
       const output = [result.stdout, result.stderr]
         .filter(Boolean)


### PR DESCRIPTION
When running from a non-GitHub directory (e.g., a GitLab repo), the github tool would fail even with `--repo` specified because `gh` CLI checks cwd remotes.

**Fix:** When `--repo` is specified, run from `~` instead of cwd. No git repo there, so gh uses `--repo` as intended.

```typescript
const cwd = repoFlag ? homedir() : undefined;
```

Simpler than env var overrides—just sidestep the issue entirely.