### PR TITLE
fix: change concept insert shortcut from ctrl+i to ctrl+shift+i

### DIFF
--- a/extensions/collaboration.ts
+++ b/extensions/collaboration.ts
@@ -2,7 +2,7 @@
  * Collaboration framework extension.
  *
  * - /concept: Manage concept emphasis (load, unload, boost, reduce)
- * - ctrl+i: Insert concept reference at cursor
+ * - ctrl+shift+i: Insert concept reference at cursor
  * - Auto-loads concepts from `cf:name` markers (recursive)
  * - Injects preamble + loaded concepts into system prompt
  * - Shows loaded concepts in status bar
@@ -242,8 +242,8 @@ ${conceptContents.join("\n\n---\n\n")}
     updateStatus(ctx);
   });
 
-  // ctrl+i shortcut - insert concept reference at cursor
-  pi.registerShortcut("ctrl+i", {
+  // ctrl+shift+i shortcut - insert concept reference at cursor
+  pi.registerShortcut("ctrl+shift+i", {
     description: "Insert concept reference",
     handler: async (ctx) => {
       const available = getAvailableConcepts();


### PR DESCRIPTION
## Summary

Changes the concept insert shortcut from `ctrl+i` to `ctrl+shift+i`.

## Problem

`ctrl+i` sends the same ASCII code as Tab (ASCII 9) in terminals. This caused the concept picker to intercept Tab keypresses, breaking autocomplete functionality.

## Solution

Use `ctrl+shift+i` instead, which:
- Avoids the Tab collision
- Doesn't conflict with any pi built-in shortcuts
- Maintains semantic connection to "insert"

Fixes #164