### PR TITLE
Simplify github tool: cwd-only for repo-scoped commands

### DIFF
--- a/concepts/github-preferences.md
+++ b/concepts/github-preferences.md
@@ -2,7 +2,7 @@
 
 Preferences for GitHub operations in dyreby/* repos:
 
-- **Repo flag**: Always use `--repo owner/repo` explicitly. Don't rely on cwd detection.
+- **Work from repo directory**: Repo-scoped commands (pr, issue, release) must be run from within the target repo. Use the workspace tool or cd to switch contexts.
 - **Branching**: Never commit directly to main. Always create a branch and PR for changes—even small fixes.
 - **PR creation**: When creating a PR as john-agent, request dyreby's review.
 - **PR updates**: After pushing changes that address review feedback, re-request review.

--- a/extensions/github/index.ts
+++ b/extensions/github/index.ts
@@ -31,6 +31,8 @@ const COMMUNICATION_STYLE = `Use "I" for your own perspective. Respond to contex
 /** Instruction to use the github tool for gh commands */
 const GITHUB_TOOL_INSTRUCTION = `For GitHub CLI operations (gh commands), use the \`github\` tool instead of bash. The github tool handles identity switching automatically.
 
+Repo-scoped commands (pr, issue, release) must be run from within the target repo directory. Global commands (search, notifications, cross-repo queries) work from anywhere.
+
 Apply \`cf:github-preferences\`.`;
 
 export default function (pi: ExtensionAPI) {


### PR DESCRIPTION
Simplifies the github tool by requiring repo-scoped commands to run from within the target repo directory.

**Changes:**
- Repo-scoped commands (pr, issue, release) now require cwd to be in the target repo
- Global commands (search, status, notifications, auth) work from anywhere  
- Remove `--repo` flag support for repo-scoped commands
- Identity always determined by cwd

**Why:**
The `--repo` flag created edge cases (see #165) where gh CLI would check cwd remotes before respecting the flag. Instead of patching around this, we simplify: to work on a repo, be in that repo.

This sets up for a workspace tool (separate PR) that handles the context-switching UX—opening tmux sessions in the right repo with status bar context.

Closes the design gap that #165 was trying to solve.