### PR TITLE
Add workspace tool for repo context-switching

### DIFF
--- a/extensions/workspace.ts
+++ b/extensions/workspace.ts
@@ -1,0 +1,133 @@
+/**
+ * Workspace tool for context-switching between repos.
+ *
+ * Opens a new tmux window in the target repo directory with status bar context.
+ * Use this to transition from discovery (cross-repo queries) to focused work.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+
+/** Base path for repo checkouts */
+const REPOS_BASE = join(homedir(), "repos");
+
+/**
+ * Find a repo's local path.
+ * Looks in ~/repos/{owner}/{repo}
+ */
+function findRepoPath(owner: string, repo: string): string | null {
+  const path = join(REPOS_BASE, owner, repo);
+  return existsSync(path) ? path : null;
+}
+
+/**
+ * Build tmux window name from repo and optional context.
+ */
+function buildWindowName(owner: string, repo: string, context?: string): string {
+  const base = `${owner}/${repo}`;
+  return context ? `${base} ${context}` : base;
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.registerTool({
+    name: "workspace",
+    label: "Workspace",
+    description:
+      "Open a new tmux window for working on a specific repo. " +
+      "Use this to switch context from discovery to focused work on a repo.",
+    parameters: Type.Object({
+      repo: Type.String({
+        description:
+          'Repository in "owner/repo" format (e.g., "dyreby/collaboration-framework")',
+      }),
+      context: Type.Optional(
+        Type.String({
+          description:
+            'Optional context to show in window name (e.g., "#165" for a PR, "fix-bug" for a branch)',
+        })
+      ),
+    }),
+
+    async execute(_toolCallId, params, _signal) {
+      const { repo, context } = params as { repo: string; context?: string };
+
+      // Parse owner/repo
+      const parts = repo.split("/");
+      if (parts.length !== 2) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Invalid repo format: "${repo}". Expected "owner/repo".`,
+            },
+          ],
+          isError: true,
+        };
+      }
+      const [owner, repoName] = parts;
+
+      // Find local path
+      const repoPath = findRepoPath(owner, repoName);
+      if (!repoPath) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Repo not found locally: ${repo}\nExpected at: ${join(REPOS_BASE, owner, repoName)}\n\nClone it first, or check the path.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Check if we're in tmux
+      if (!process.env.TMUX) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Not running in tmux. The workspace tool requires tmux to open new windows.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Build window name
+      const windowName = buildWindowName(owner, repoName, context);
+
+      // Open new tmux window
+      const result = await pi.exec("tmux", [
+        "new-window",
+        "-n",
+        windowName,
+        "-c",
+        repoPath,
+      ]);
+
+      if (result.code !== 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to open tmux window: ${result.stderr}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Opened workspace: ${windowName}\nPath: ${repoPath}\n\nSwitch to that tmux window to continue work there.`,
+          },
+        ],
+      };
+    },
+  });
+}


### PR DESCRIPTION
Adds a workspace tool that opens a new tmux window in a target repo directory.

**Usage:**
```
workspace({ repo: "dyreby/collaboration-framework", context: "#165" })
```

Opens a tmux window named `dyreby/collaboration-framework #165` with cwd in that repo.

**Flow this enables:**
1. Start from ~ with discovery queries ("what PRs need review?")
2. Pick something to work on
3. Agent suggests: "Open workspace for dyreby/collaboration-framework#165?"
4. User confirms → new tmux window opens
5. Work continues in that window with repo-scoped github commands

**Notes:**
- Expects repos at `~/repos/{owner}/{repo}`
- Requires tmux (errors clearly if not available)
- Window name includes optional context (PR number, branch, etc.)

Pairs with #167 (github tool cwd-only simplification).