### PR TITLE
Remove stale --repo reference from comment

### DIFF
--- a/extensions/github/gh-command.ts
+++ b/extensions/github/gh-command.ts
@@ -29,7 +29,7 @@ export interface GhToolContext {
   pi: ExtensionAPI;
   getConfigDir: () => string;
   getAccount: () => string;
-  /** Fallback repo owner from cwd detection (used when --repo not specified) */
+  /** Repo owner from cwd detection */
   getRepoOwner: () => string | null;
   authError: string | null;
 }


### PR DESCRIPTION
The comment on `getRepoOwner` still referenced `--repo` flag behavior, which was removed in #167.