### PR TITLE
Add discovery prompt template

### DIFF
--- a/.pi/prompts/discovery.md
+++ b/.pi/prompts/discovery.md
@@ -1,0 +1,13 @@
+---
+description: Cross-repo discovery - check what needs attention
+---
+Check what needs my attention across repos. Include:
+- Notifications
+- PRs where my review is requested
+- PRs I authored that have new activity
+
+**Workflow guidance:**
+- Use the `github` tool for cross-repo queries (works from any directory)
+- Summarize what needs attention, grouped by urgency/type
+- When I pick something to work on, offer to open a workspace: `workspace({ repo: "owner/repo", context: "#123" })`
+- Work continues in the new tmux window with repo-scoped commands


### PR DESCRIPTION
Adds a `/discovery` prompt template for the cross-repo workflow.

**Usage:**
Type `/discovery` to start a session that checks:
- Notifications
- PRs requesting your review
- PRs you authored with new activity

**Flow:**
1. `/discovery` → agent checks what needs attention
2. Pick something to work on
3. Agent offers: "Open workspace for owner/repo#123?"
4. New tmux window opens for focused work

Companion to #168 (workspace tool).