### PR TITLE
Change concept insert hotkey from ctrl+shift+i to alt+c

### DIFF
--- a/extensions/collaboration.ts
+++ b/extensions/collaboration.ts
@@ -2,7 +2,7 @@
  * Collaboration framework extension.
  *
  * - /concept: Manage concept emphasis (load, unload, boost, reduce)
- * - ctrl+shift+i: Insert concept reference at cursor
+ * - alt+c: Insert concept reference at cursor
  * - Auto-loads concepts from `cf:name` markers (recursive)
  * - Injects preamble + loaded concepts into system prompt
  * - Shows loaded concepts in status bar
@@ -244,8 +244,8 @@ ${conceptContents.join("\n\n---\n\n")}
     updateStatus(ctx);
   });
 
-  // ctrl+shift+i shortcut - insert concept reference at cursor
-  pi.registerShortcut("ctrl+shift+i", {
+  // alt+c shortcut - insert concept reference at cursor
+  pi.registerShortcut("alt+c", {
     description: "Insert concept reference",
     handler: async (ctx) => {
       const available = getAvailableConcepts();


### PR DESCRIPTION
ctrl+shift+i doesn't work reliably in many terminal emulators (they either intercept it or don't pass it through).

alt+c is:
- Mnemonic (c for concept)
- Works across terminal emulators
- Not claimed by pi's built-in keybindings