### PR TITLE
Add /concept all to load every concept at once

### DIFF
--- a/extensions/collaboration.ts
+++ b/extensions/collaboration.ts
@@ -132,11 +132,30 @@ export default function (pi: ExtensionAPI) {
 
   // /concept command - manage concept emphasis
   pi.registerCommand("concept", {
-    description: "Manage concept emphasis (load, unload, boost, reduce)",
-    handler: async (_args, ctx) => {
+    description: "Manage concept emphasis (load, unload, boost, reduce, all)",
+    handler: async (args, ctx) => {
       const available = getAvailableConcepts();
       if (available.length === 0) {
         ctx.ui.notify("No concepts found in concepts/", "error");
+        return;
+      }
+
+      // /concept all - load every available concept
+      if (args.trim().toLowerCase() === "all") {
+        let loaded = 0;
+        for (const name of available) {
+          if (!sessionConcepts.has(name)) {
+            sessionConcepts.set(name, 1);
+            loaded++;
+          }
+        }
+        updateStatus(ctx);
+        ctx.ui.notify(
+          loaded > 0
+            ? `Loaded ${loaded} concept${loaded > 1 ? "s" : ""} (${available.length} total)`
+            : `All ${available.length} concepts already loaded`,
+          "info"
+        );
         return;
       }
 


### PR DESCRIPTION
Adds an `all` subcommand to `/concept` that loads every available concept in one shot.

`/concept all` reads the concepts directory and loads anything not already in the session. Skips already-loaded concepts so it's safe to run multiple times.

This avoids hardcoding concept names (unlike a prompt-based approach) — stays current automatically when concepts are added or removed.