### PR TITLE
Add rust-preferences concept

### DIFF
--- a/concepts/rust-preferences.md
+++ b/concepts/rust-preferences.md
@@ -1,0 +1,12 @@
+# rust-preferences
+
+Preferences for Rust code in dyreby/* repos:
+
+- **Linting**: `clippy::pedantic`, no warnings allowed.
+- **Idiomatic Rust**: Modern, correct, take advantage of new features for readability.
+- **Imports**: Everything imported at the top of the module scope. No inline qualified paths (`std::fs::read`, `serde::Serialize`). The reader should see all dependencies at a glance.
+- **Comments**: Semantic line breaks. Break at sentence boundaries or natural semantic units, not at arbitrary column widths. Each line should be a complete thought. When near a natural wrap point, prefer the semantic break. Otherwise wrap at whatever makes sense or the linter suggests.
+- **Comments**: Periods at the end of sentences unless inconsistent within formatting context (e.g., short list items without periods). Short sentence comments get the period.
+- **Formatting**: Line breaks between variants and fields that have doc comments.
+- **Time**: Prefer `jiff` over `chrono`.
+- **Module style**: Modern — `foo.rs` + `foo/` over `foo/mod.rs`.


### PR DESCRIPTION
## What

New concept encoding Rust coding preferences for dyreby/* repos:

- Clippy pedantic, no warnings
- Imports at top of module scope, no inline qualified paths
- Semantic line breaks in comments (break at sentence boundaries, not column widths)
- Periods on comments unless inconsistent with formatting context
- Line breaks between doc-commented variants/fields
- jiff over chrono
- Modern module style (`foo.rs` + `foo/` over `foo/mod.rs`)

## Context

These preferences were surfaced and refined during dyreby/helm#21 review. Some were already listed as seed preferences in dyreby/helm#9. Encoding them as a concept makes them available in sessions now, independent of Helm's eventual concept-snapshot support.

dyreby/helm#22 tracks applying these consistently to existing Helm code.