### PR TITLE
Clarify import preference: don't mix self with specific items

### DIFF
--- a/concepts/rust-preferences.md
+++ b/concepts/rust-preferences.md
@@ -4,7 +4,7 @@ Preferences for Rust code in dyreby/* repos:
 
 - **Linting**: `clippy::pedantic`, no warnings allowed.
 - **Idiomatic Rust**: Modern, correct, take advantage of new features for readability.
-- **Imports**: Everything imported at the top of the module scope. No inline qualified paths (`std::fs::read`, `serde::Serialize`). The reader should see all dependencies at a glance.
+- **Imports**: Everything imported at the top of the module scope. No inline qualified paths (`std::fs::read`, `serde::Serialize`). The reader should see all dependencies at a glance. When importing a module with `self` (e.g., `use std::fs`), use the module path for its items in code (`fs::Metadata`, `fs::read`). Don't also import specific items alongside `self` — pick one level of abstraction.
 - **Comments**: Semantic line breaks. Break at sentence boundaries or natural semantic units, not at arbitrary column widths. Each line should be a complete thought. When near a natural wrap point, prefer the semantic break. Otherwise wrap at whatever makes sense or the linter suggests.
 - **Comments**: Periods at the end of sentences unless inconsistent within formatting context (e.g., short list items without periods). Short sentence comments get the period.
 - **Formatting**: Line breaks between variants and fields that have doc comments.


### PR DESCRIPTION
## What

Refines the **Imports** bullet in `cf:rust-preferences` to capture a preference that surfaced during [dyreby/helm#22](https://github.com/dyreby/helm/issues/22):

When importing a module with `self` (e.g., `use std::fs`), use the module path for its items in code (`fs::Metadata`, `fs::read`). Don't also import specific items alongside `self` — pick one level of abstraction.

**Before** (redundant):
```rust
use std::fs::{self, Metadata};
// then using both fs::read(...) and Metadata::is_dir
```

**After** (pick one level):
```rust
use std::fs;
// then fs::read(...) and fs::Metadata::is_dir
```