### PR TITLE
Add guidance for replying to inline review comments

### DIFF
--- a/concepts/github-preferences.md
+++ b/concepts/github-preferences.md
@@ -7,6 +7,7 @@ Preferences for GitHub operations in dyreby/* repos:
 - **PR creation**: When creating a PR as john-agent, request dyreby's review.
 - **PR updates**: After pushing changes that address review feedback, re-request review.
 - **Addressing feedback**: Check *both* PR-level comments (`github pr view --comments`) *and* inline review comments (`github api repos/{owner}/{repo}/pulls/{n}/comments`). Reply to each, summarizing what changed and why. Include the commit SHA.
+- **Replying to inline comments**: Use `github api repos/{owner}/{repo}/pulls/{n}/comments --method POST -f body="..." -F in_reply_to={comment_id}` to reply in-thread. Don't use PR-level comments to respond to inline feedback.
 - **Before merging**: Check for approval status AND inline review comments. Approval doesn't mean "no feedback" — sometimes there are nitpicks or suggestions worth addressing first.
 - **Merging**: Always use squash merge (`--squash`).
 - **Review timing**: Don't re-request review while still iterating in conversation. The PR should reflect aligned work, not a mid-discussion snapshot.


### PR DESCRIPTION
The **Addressing feedback** bullet in `github-preferences` says to check inline comments but doesn't explain how to reply in-thread. This adds a new bullet documenting the API call (`--method POST ... -F in_reply_to={comment_id}`) and clarifying that PR-level comments shouldn't be used to respond to inline feedback.