### PR TITLE
Add check-in prompt

### DIFF
--- a/prompts/check-in.md
+++ b/prompts/check-in.md
@@ -7,7 +7,7 @@ Apply `cf:alignment`, `cf:lightest-touch`.
 
 ## Why
 
-`cf:propositions` — your model is incomplete. You're working with inferences, not ground truth. The other party has context you can't derive alone, and you have context they can't see. Pausing to surface gaps is cheaper than building on them.
+`cf:propositions` — your model is incomplete. You're working with inferences, not ground truth. The other party has context you can't derive alone, and you have context they can't see. The cost of a check-in is low. The cost of building on a wrong assumption compounds.
 
 ## What
 
@@ -22,9 +22,3 @@ Two moves:
 Ask what-level questions, not how-level questions. How-questions accept the frame and ask for preferences. What-questions challenge the frame and find gaps in understanding.
 
 The difference: "should the help text show the full workflow?" is a how-question wearing a what-question's clothes. "Should the help text *be* the source of truth, or should it point to docs?" reframes what the help text is for — a fundamentally better question that changes which how-questions are even worth asking.
-
-## When
-
-When you notice momentum without recent alignment. When the work feels productive but you can't articulate *why* the current approach is right. When you're three decisions deep and haven't checked whether decision one still holds.
-
-The cost of a check-in is low. The cost of building on a wrong assumption compounds.


### PR DESCRIPTION
A prompt for mid-conversation alignment checks. Loads `cf:alignment`, `cf:lightest-touch`, and `cf:propositions`, then prescribes two moves: surface uncertainties you're pushing past, and surface context the other party should know. Structured as Why / What / How.