### PR TITLE
Load all concepts in workspace-spawned sessions

### DIFF
--- a/extensions/collaboration.ts
+++ b/extensions/collaboration.ts
@@ -260,6 +260,14 @@ ${conceptContents.join("\n\n---\n\n")}
   // Reset session state on session start
   pi.on("session_start", async (_event, ctx) => {
     sessionConcepts.clear();
+
+    // Spawned sessions (via workspace tool) load all concepts automatically
+    if (process.env.PI_LOAD_ALL_CONCEPTS === "1") {
+      for (const name of getAvailableConcepts()) {
+        sessionConcepts.set(name, 1);
+      }
+    }
+
     updateStatus(ctx);
   });
 

--- a/extensions/workspace.ts
+++ b/extensions/workspace.ts
@@ -135,7 +135,9 @@ export default function (pi: ExtensionAPI) {
       if (prompt) {
         // Escape single quotes in the prompt for shell
         const escapedPrompt = prompt.replace(/'/g, "'\\''");
-        const piCommand = `pi --prompt '${escapedPrompt}'`;
+        // PI_LOAD_ALL_CONCEPTS signals the collaboration extension to load
+        // all concepts at session start (equivalent to /concept all)
+        const piCommand = `PI_LOAD_ALL_CONCEPTS=1 pi --prompt '${escapedPrompt}'`;
 
         const piResult = await pi.exec("tmux", [
           "send-keys",


### PR DESCRIPTION
## Why

Spawned sessions (via the workspace tool) start without shared concepts loaded. The agent needs these to collaborate effectively — particularly `cf:github-preferences` and `cf:writing-style` since most spawned work results in GitHub actions. Rather than depend on the spawning agent to pick the right subset, load all concepts. The set is small and context is plentiful at session start.

## What

When the workspace tool spawns a session with a prompt, all concepts load automatically — equivalent to `/concept all`. They appear in the status bar footer so a human switching to that tmux window can verify the shared context at a glance.

## How

- **workspace.ts**: Sets `PI_LOAD_ALL_CONCEPTS=1` on the `pi` process when spawning with a prompt
- **collaboration.ts**: Checks the env var in `session_start` and populates `sessionConcepts` with all available concepts

The env var is scoped to the pi process only (not the shell session). Any `cf:` markers in the prompt still accumulate additional emphasis on top of the base loading.

Closes #187