### PR TITLE
Add model alignment practice to best-practices

### DIFF
--- a/concepts/best-practices.md
+++ b/concepts/best-practices.md
@@ -21,3 +21,5 @@ Another: lead with "what" in PRs and issues. The purpose, the change, the intent
 Another: don't push mid-conversation. When iterating on design with a human in an agent session, align first, push when aligned. Pushing and re-requesting review while the conversation is still active creates noise and fragments the trail.
 
 Another: orient before building. At session start in a repo or project, read the README, contributing guide, and whatever high-level docs the project has — vision, architecture, design docs, agent instructions — before diving into code. The codebase tells you what exists; these docs tell you why it exists and where it's going.
+
+Another: align on the model before building on it. When a feature introduces or changes data types, walk through the model — naming, structure, serialization — before writing the code that uses it. The model is the foundation; friction there propagates to every layer above. A design conversation in the issue is cheaper than a redesign in review.


### PR DESCRIPTION
Adds a new entry: align on the data model (naming, structure, serialization) before building features on top of it. Model friction propagates to every layer above — a design conversation in the issue is cheaper than a redesign in review.

**Context**: In dyreby/helm#40, the action model (Act/PullRequestAct/IssueAct naming, unnecessary UUIDs, inconsistent serde tagging) wasn't reviewed before the feature was built on it. The PR had to be closed and redone (dyreby/helm#42). This practice encodes the lesson.