### PR TITLE
Add read-before-writing practice to best-practices

### DIFF
--- a/concepts/best-practices.md
+++ b/concepts/best-practices.md
@@ -23,3 +23,5 @@ Another: don't push mid-conversation. When iterating on design with a human in a
 Another: orient before building. At session start in a repo or project, read the README, contributing guide, and whatever high-level docs the project has — vision, architecture, design docs, agent instructions — before diving into code. The codebase tells you what exists; these docs tell you why it exists and where it's going.
 
 Another: align on the model before building on it. When a feature introduces or changes data types, walk through the model — naming, structure, serialization — before writing the code that uses it. The model is the foundation; friction there propagates to every layer above. A design conversation in the issue is cheaper than a redesign in review.
+
+Another: read before writing. When modifying an existing file, read it first. Overwriting replaces the entire file — use surgical edits for existing content, and only full writes when you've accounted for what's already there.


### PR DESCRIPTION
Adds a practice encoding: read before writing. When modifying an existing file, read it first — overwriting replaces the entire file.

Born from a real failure: using `write` to create what was assumed to be a new file (CONTRIBUTING.md), but it already existed, overwriting all its content. The fix: surgical edits for existing content, full writes only when you've accounted for what's already there.