### PR TITLE
Add cargo fmt verification step to rust-preferences

### DIFF
--- a/concepts/rust-preferences.md
+++ b/concepts/rust-preferences.md
@@ -3,7 +3,7 @@
 Preferences for Rust code in dyreby/* repos:
 
 - **Linting**: `clippy::pedantic`, no warnings allowed.
-- **Formatting**: Run `cargo fmt --check` before committing. CI enforces this.
+- **Formatting**: Run `cargo fmt --check` before committing. CI usually enforces this.
 - **Idiomatic Rust**: Modern, correct, take advantage of new features for readability.
 - **Imports**: Everything imported at the top of the module scope. No inline qualified paths (`std::fs::read`, `serde::Serialize`). The reader should see all dependencies at a glance. When importing a module (e.g., `use std::fs`), use the module path for its items in code (`fs::Metadata`, `fs::read`). Don't also import specific items from the same module — pick one level of abstraction. When a trait must be in scope for method calls (e.g., `io::Read` for `.read_to_string()`), import it separately below the grouped `std` import with a comment explaining why.
 - **Comments**: Semantic line breaks. Break at sentence boundaries or natural semantic units, not at arbitrary column widths. Each line should be a complete thought. When near a natural wrap point, prefer the semantic break. Otherwise wrap at whatever makes sense or the linter suggests.


### PR DESCRIPTION
Adds a bullet to `rust-preferences` for running `cargo fmt --check` before committing. CI enforces this, so catching it locally avoids unnecessary round-trips.

Closes #195