### PR TITLE
Break out import rules in rust-preferences for clarity

### DIFF
--- a/concepts/rust-preferences.md
+++ b/concepts/rust-preferences.md
@@ -6,7 +6,7 @@ Preferences for Rust code in dyreby/* repos:
 - **Formatting**: Run `cargo fmt --check` before committing. CI usually enforces this.
 - **Idiomatic Rust**: Modern, correct, take advantage of new features for readability.
 - **Imports**: Everything imported at the top of the module scope.
-  No inline qualified paths (`std::fs::read`, `serde::Serialize`).
+  No inline qualified paths (`std::fs::read`, `serde::Serialize`) unless it improves readability.
   The reader should see all dependencies at a glance.
 - **Import merging**: Merge as aggressively as possible.
   Combine imports from the same crate into a single `use` statement with nested braces.
@@ -23,11 +23,9 @@ Preferences for Rust code in dyreby/* repos:
   use std::fs;
   use std::io::{self, Read};
   ```
-- **Import style**: When importing a module (e.g., `use std::fs`),
-  use the module path for its items in code (`fs::Metadata`, `fs::read`).
+- **Import style**: When importing a module (e.g., `use std::fs`), use the module path for its items in code (`fs::Metadata`, `fs::read`).
   Don't also import specific items from the same module — pick one level of abstraction.
-  When a trait must be in scope for method calls (e.g., `io::Read` for `.read_to_string()`),
-  import it separately below the grouped import with a comment explaining why.
+  When a trait must be in scope for method calls (e.g., `io::Read` for `.read_to_string()`), import it separately below the grouped import with a comment explaining why.
 - **Comments**: Semantic line breaks. Break at sentence boundaries or natural semantic units, not at arbitrary column widths. Each line should be a complete thought. When near a natural wrap point, prefer the semantic break. Otherwise wrap at whatever makes sense or the linter suggests.
 - **Comments**: Periods at the end of sentences unless inconsistent within formatting context (e.g., short list items without periods). Short sentence comments get the period.
 - **Formatting**: Line breaks between variants and fields that have doc comments.


### PR DESCRIPTION
Splits the single Imports bullet into three focused bullets:

- **Imports**: top-of-module, no inline paths
- **Import merging**: merge aggressively with nested braces, with a yes/no code example
- **Import style**: module-level vs item-level imports, trait import convention

The merging rule was buried in a dense paragraph and agents were skipping it. Separate bullets with an explicit code example should make it stick.