### PR TITLE
workspace: add required model and thinkingLevel args

### DIFF
--- a/extensions/workspace.ts
+++ b/extensions/workspace.ts
@@ -50,7 +50,7 @@ export default function (pi: ExtensionAPI) {
         description:
           'Model to use (e.g., "claude-opus-4", "claude-sonnet-4"). Must be explicitly provided by the user.',
       }),
-      thinkingLevel: Type.String({
+      thinking: Type.String({
         description:
           'Thinking level: off, minimal, low, medium, high, xhigh. Must be explicitly provided by the user.',
       }),
@@ -69,10 +69,10 @@ export default function (pi: ExtensionAPI) {
     }),
 
     async execute(_toolCallId, params, _signal) {
-      const { repo, model, thinkingLevel, context, prompt } = params as {
+      const { repo, model, thinking, context, prompt } = params as {
         repo: string;
         model: string;
-        thinkingLevel: string;
+        thinking: string;
         context?: string;
         prompt?: string;
       };
@@ -145,7 +145,7 @@ export default function (pi: ExtensionAPI) {
 
       // Build pi command with model and thinking args
       const escapedModel = model.replace(/'/g, "'\\''");
-      const escapedThinking = thinkingLevel.replace(/'/g, "'\\''");
+      const escapedThinking = thinking.replace(/'/g, "'\\''");
       const modelArgs = `--model '${escapedModel}' --thinking '${escapedThinking}'`;
 
       // Start pi with context if prompt provided
@@ -179,7 +179,7 @@ export default function (pi: ExtensionAPI) {
           content: [
             {
               type: "text",
-              text: `Opened workspace: ${windowName}\nPath: ${repoPath}\nStarted pi with ${model} (thinking: ${thinkingLevel}).\n\nSwitch to that tmux window to continue.`,
+              text: `Opened workspace: ${windowName}\nPath: ${repoPath}\nStarted pi with ${model} (thinking: ${thinking}).\n\nSwitch to that tmux window to continue.`,
             },
           ],
         };
@@ -211,7 +211,7 @@ export default function (pi: ExtensionAPI) {
         content: [
           {
             type: "text",
-            text: `Opened workspace: ${windowName}\nPath: ${repoPath}\nStarted pi with ${model} (thinking: ${thinkingLevel}).\n\nSwitch to that tmux window to continue.`,
+            text: `Opened workspace: ${windowName}\nPath: ${repoPath}\nStarted pi with ${model} (thinking: ${thinking}).\n\nSwitch to that tmux window to continue.`,
           },
         ],
       };


### PR DESCRIPTION
## Summary

Add required `model` and `thinkingLevel` parameters to the workspace tool, supporting commission dispatch (Option B from #194).

## Changes

- **`model` (required)**: Model to use in the spawned pi session (e.g., `claude-opus-4`, `claude-sonnet-4`)
- **`thinkingLevel` (required)**: Thinking level (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`)
- Both are passed through as `--model` and `--thinking` CLI flags
- Pi is now always started in the new window (previously only when a prompt was provided)
- Parameter descriptions note that values must be explicitly provided by the user

## Design decision

Keeps workspace as a primitive in this repo (Option B). Bridge calls it, helm doesn't need to know about it. The tool is generic context-switching plumbing with commission support.

Closes #194