### PR TITLE
concepts/github-preferences: prohibit inline --body, require --body-file

### DIFF
--- a/concepts/github-preferences.md
+++ b/concepts/github-preferences.md
@@ -10,4 +10,5 @@ Preferences for GitHub operations in dyreby/* repos:
 - **Replying to inline comments**: Use `github api repos/{owner}/{repo}/pulls/{n}/comments --method POST -f body="..." -F in_reply_to={comment_id}` to reply in-thread. Don't use PR-level comments to respond to inline feedback.
 - **Before merging**: Check for approval status AND inline review comments. Approval doesn't mean "no feedback" — sometimes there are nitpicks or suggestions worth addressing first.
 - **Merging**: Always use squash merge (`--squash`).
+- **Body formatting**: Never use `--body` inline for `pr create` or `issue create`. Inline strings don't render `\n` as newlines and the shell interprets backticks. Always write the body to a temp file and pass `--body-file /tmp/body.md`.
 - **Review timing**: Don't re-request review while still iterating in conversation. The PR should reflect aligned work, not a mid-discussion snapshot.

--- a/concepts/github-preferences.md
+++ b/concepts/github-preferences.md
@@ -10,5 +10,5 @@ Preferences for GitHub operations in dyreby/* repos:
 - **Replying to inline comments**: Use `github api repos/{owner}/{repo}/pulls/{n}/comments --method POST -f body="..." -F in_reply_to={comment_id}` to reply in-thread. Don't use PR-level comments to respond to inline feedback.
 - **Before merging**: Check for approval status AND inline review comments. Approval doesn't mean "no feedback" — sometimes there are nitpicks or suggestions worth addressing first.
 - **Merging**: Always use squash merge (`--squash`).
-- **Body formatting**: Never use `--body` inline for `pr create` or `issue create`. Inline strings don't render `\n` as newlines and the shell interprets backticks. Always write the body to a temp file and pass `--body-file /tmp/body.md`.
+- **Body formatting**: Never use `--body` inline for `pr create` or `issue create`. Inline strings don't render `\n` as newlines and the shell interprets backticks. Always write the body to a temp file and pass `--body-file` with a path from `mktemp`.
 - **Review timing**: Don't re-request review while still iterating in conversation. The PR should reflect aligned work, not a mid-discussion snapshot.


### PR DESCRIPTION
Adds a blanket prohibition on inline `--body` for `gh pr create` / `gh issue create`.

**Problem**: Inline strings don't render `\n` as newlines, and the shell interprets backticks — leading to broken formatting that keeps recurring. The workaround (create then edit, or `--body-file`) is easy to forget when the inline form looks like it should work.

**Fix**: Encode it as a hard rule — always use `--body-file /tmp/body.md`. Removes the judgment call entirely.

Closes #212 (body formatting half; the workspace/cd scope issue remains open separately).
