### PR TITLE
Update coherent-evolution concept: what/how model with decision rules

### DIFF
--- a/concepts/alignment.md
+++ b/concepts/alignment.md
@@ -4,7 +4,9 @@ Alignment is agreement on what we're doing and why. Perfect alignment between ag
 
 ## The Structure
 
-Alignment is hierarchical: *why* → *what* → *how*. And each *how* contains its own why/what/how, all the way down.
+Alignment is hierarchical: *what* and *how*, recurring at every level. Each *how* contains its own *what* and *how*, all the way down. The *why* at any level is the *what* from the level above — look up to find it.
+
+This is the same recursive structure described in `cf:coherent-evolution`. CE gives it full treatment in the context of software; here it applies to any collaboration.
 
 At the top: a shared objective. Below that: agreement on approach. Below that: agreement on implementation. All the way down to tabs vs. spaces.
 

--- a/concepts/coherent-evolution.md
+++ b/concepts/coherent-evolution.md
@@ -1,9 +1,37 @@
 # Coherent Evolution
 
-A model for building software together. Source of truth: [dyreby/coherent-evolution](https://github.com/dyreby/coherent-evolution).
+A model for staying aligned as software evolves. Source of truth: [dyreby/coherent-evolution](https://github.com/dyreby/coherent-evolution).
 
-Software has levels of care: charter (why we're here), vision (what serves that purpose today), design (how it gets built), implementation (the code to do it). Each level constrains the next. Each contains its own why, what, and how — all the way down to tabs vs. spaces.
+## The model
 
-Change means different things at different levels. Charter changes mean a new project. Vision changes mean growth. Design changes mean learning. Implementation changes are the work.
+Software is built on layers of *what* and *how* decisions.
+Every *how* has its own *what* and *how*, repeating downward through layers of detail.
+Fewer people are involved at each successive level.
 
-Not everyone needs to care at every level — that's a gift, not a gap. Share the understanding, build the trust, find the level where alignment lives and the work gets light.
+People engage where they care about the *what*.
+Once the shared understanding at that level is sufficient, they release the *how* to the people working at the next level down.
+Alignment at each level encapsulates the work below it.
+
+## How to use this
+
+**Before acting, check: is the *what* at my level shared?**
+If yes, the *how* is yours — work independently.
+If not, align on the *what* first. Don't solve the *how* of a *what* that isn't settled.
+
+**When friction appears, locate it.**
+Persistent disagreement about a *how* often means the *what* behind it isn't actually shared.
+The move is to step up a level: "I think we're disagreeing about the *what*, not the *how*."
+
+**When something changes, ask: which level does it affect?**
+A change to a *how* stays contained.
+A change to a *what* cascades to everything below it.
+The response and the people involved depend on the level.
+
+**When joining a project or session, apply the onboarding test.**
+At your level, do you have what you need to understand the *what* and contribute to the *how*?
+If not, ask for it before building.
+
+## What it's not
+
+Not a process framework. Not governance. Not a replacement for knowing how to build things.
+It's a shared language for locating alignment problems, not a system for managing them.

--- a/concepts/coherent-evolution.md
+++ b/concepts/coherent-evolution.md
@@ -14,6 +14,9 @@ Alignment at each level encapsulates the work below it.
 
 ## How to use this
 
+CE tells you where to point the OODA loop.
+When friction appears, observe the level, orient on whether the *what* is shared, decide whether to align or act, and proceed.
+
 **Before acting, check: is the *what* at my level shared?**
 If yes, the *how* is yours — work independently.
 If not, align on the *what* first. Don't solve the *how* of a *what* that isn't settled.

--- a/concepts/coherent-evolution.md
+++ b/concepts/coherent-evolution.md
@@ -14,7 +14,7 @@ Alignment at each level encapsulates the work below it.
 
 ## How to use this
 
-CE tells you where to point the OODA loop.
+Coherent Evolution tells you where to point the OODA loop.
 When friction appears, observe the level, orient on whether the *what* is shared, decide whether to align or act, and proceed.
 
 **Before acting, check: is the *what* at my level shared?**


### PR DESCRIPTION
Updates the coherent-evolution concept to reflect the rewritten CE model (dyreby/coherent-evolution#21).

The old concept described four fixed levels (charter/vision/design/implementation) with change classification. The new concept reflects the recursive what/how model and adds actionable decision rules for agent sessions:

1. **Before acting** — check if the *what* at your level is shared
2. **When friction appears** — locate the level; step up if the *what* isn't shared
3. **When something changes** — identify which level it affects
4. **When joining** — apply the onboarding test before building

These are designed to accelerate OODA loops on alignment. An agent loading this concept cold should know what to check and when, without needing to read the full CE docs.

Also updates `cf:alignment` to adopt the what/how framing and reference `cf:coherent-evolution` as the source model.

Resolves #216
